### PR TITLE
don't run travis jobs on development branches

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,10 @@
 language: python
 
+# whitelist branches on which tests will be run
+branches:
+  only:
+    - master
+
 addons:
   apt_packages:
     # needed for M2Crypto


### PR DESCRIPTION
Since now I'm running travis jobs on my repo, it's necessary to exclude development branches from travis runs.