### PR TITLE
Implement RFC 7366 - Encrypt-then-MAC

### DIFF
--- a/scripts/tls.py
+++ b/scripts/tls.py
@@ -182,6 +182,7 @@ def printGoodConnection(connection, seconds):
         print("  TACK: %s" % emptyStr)
         print(str(connection.session.tackExt))
     print("  Next-Protocol Negotiated: %s" % connection.next_proto) 
+    print("  Encrypt-then-MAC: {0}".format(connection.encryptThenMAC))
     
 
 def clientCmd(argv):

--- a/tests/tlstest.py
+++ b/tests/tlstest.py
@@ -473,6 +473,55 @@ def clientTestCmd(argv):
     assert not connection.encryptThenMAC
     connection.close()
 
+    print("Test 26.c - resumption with EtM")
+    synchro.recv(1)
+    connection = connect()
+    connection.handshakeClientCert(serverName=address[0])
+    testConnClient(connection)
+    assert isinstance(connection.session.serverCertChain, X509CertChain)
+    assert connection.session.serverName == address[0]
+    assert not connection.resumed
+    assert connection.encryptThenMAC
+    connection.close()
+    session = connection.session
+
+    # resume
+    synchro.recv(1)
+    connection = connect()
+    connection.handshakeClientCert(serverName=address[0], session=session)
+    testConnClient(connection)
+    assert isinstance(connection.session.serverCertChain, X509CertChain)
+    assert connection.session.serverName == address[0]
+    assert connection.resumed
+    assert connection.encryptThenMAC
+    connection.close()
+
+    print("Test 26.d - resumption with no EtM in 2nd handshake")
+    synchro.recv(1)
+    connection = connect()
+    connection.handshakeClientCert(serverName=address[0])
+    testConnClient(connection)
+    assert isinstance(connection.session.serverCertChain, X509CertChain)
+    assert connection.session.serverName == address[0]
+    assert not connection.resumed
+    assert connection.encryptThenMAC
+    connection.close()
+    session = connection.session
+
+    # resume
+    synchro.recv(1)
+    settings = HandshakeSettings()
+    settings.useEncryptThenMAC = False
+    connection = connect()
+    try:
+        connection.handshakeClientCert(serverName=address[0], session=session,
+                                       settings=settings)
+    except TLSRemoteAlert as e:
+        assert str(e) == "handshake_failure"
+    else:
+        raise AssertionError("No exception raised")
+    connection.close()
+
     print('Test 27 - good standard XMLRPC https client')
     address = address[0], address[1]+1
     synchro.recv(1)
@@ -925,6 +974,44 @@ def serverTestCmd(argv):
     connection = connect()
     connection.handshakeServer(certChain=x509Chain, privateKey=x509Key)
     testConnServer(connection)
+    connection.close()
+
+    print("Test 26.c - resumption with EtM")
+    synchro.send(b'R')
+    sessionCache = SessionCache()
+    connection = connect()
+    connection.handshakeServer(certChain=x509Chain, privateKey=x509Key,
+                               sessionCache=sessionCache)
+    testConnServer(connection)
+    connection.close()
+
+    # resume
+    synchro.send(b'R')
+    connection = connect()
+    connection.handshakeServer(certChain=x509Chain, privateKey=x509Key,
+                               sessionCache=sessionCache)
+    testConnServer(connection)
+    connection.close()
+
+    print("Test 26.d - resumption with no EtM in 2nd handshake")
+    synchro.send(b'R')
+    sessionCache = SessionCache()
+    connection = connect()
+    connection.handshakeServer(certChain=x509Chain, privateKey=x509Key,
+                               sessionCache=sessionCache)
+    testConnServer(connection)
+    connection.close()
+
+    # resume
+    synchro.send(b'R')
+    connection = connect()
+    try:
+        connection.handshakeServer(certChain=x509Chain, privateKey=x509Key,
+                                   sessionCache=sessionCache)
+    except TLSLocalAlert as e:
+        assert str(e) == "handshake_failure"
+    else:
+        raise AssertionError("no exception raised")
     connection.close()
 
     print("Tests 27-29 - XMLRPXC server")

--- a/tests/tlstest.py
+++ b/tests/tlstest.py
@@ -117,7 +117,7 @@ def clientTestCmd(argv):
     testConnClient(connection)
     assert(isinstance(connection.session.serverCertChain, X509CertChain))
     assert(connection.session.serverName == address[0])
-    assert connection.encryptThenMAC == True
+    assert(connection.encryptThenMAC == True)
     connection.close()
 
     print("Test 1.a - good X509, SSLv3")
@@ -453,12 +453,12 @@ def clientTestCmd(argv):
     synchro.recv(1)
     connection = connect()
     settings = HandshakeSettings()
-    assert settings.useEncryptThenMAC
+    assert(settings.useEncryptThenMAC)
     connection.handshakeClientCert(serverName=address[0], settings=settings)
     testConnClient(connection)
-    assert isinstance(connection.session.serverCertChain, X509CertChain)
-    assert connection.session.serverName == address[0]
-    assert not connection.encryptThenMAC
+    assert(isinstance(connection.session.serverCertChain, X509CertChain))
+    assert(connection.session.serverName == address[0])
+    assert(not connection.encryptThenMAC)
     connection.close()
 
     print("Test 26.b - no EtM client side")
@@ -468,9 +468,9 @@ def clientTestCmd(argv):
     settings.useEncryptThenMAC = False
     connection.handshakeClientCert(serverName=address[0], settings=settings)
     testConnClient(connection)
-    assert isinstance(connection.session.serverCertChain, X509CertChain)
-    assert connection.session.serverName == address[0]
-    assert not connection.encryptThenMAC
+    assert(isinstance(connection.session.serverCertChain, X509CertChain))
+    assert(connection.session.serverName == address[0])
+    assert(not connection.encryptThenMAC)
     connection.close()
 
     print("Test 26.c - resumption with EtM")
@@ -478,10 +478,10 @@ def clientTestCmd(argv):
     connection = connect()
     connection.handshakeClientCert(serverName=address[0])
     testConnClient(connection)
-    assert isinstance(connection.session.serverCertChain, X509CertChain)
-    assert connection.session.serverName == address[0]
-    assert not connection.resumed
-    assert connection.encryptThenMAC
+    assert(isinstance(connection.session.serverCertChain, X509CertChain))
+    assert(connection.session.serverName == address[0])
+    assert(not connection.resumed)
+    assert(connection.encryptThenMAC)
     connection.close()
     session = connection.session
 
@@ -490,10 +490,10 @@ def clientTestCmd(argv):
     connection = connect()
     connection.handshakeClientCert(serverName=address[0], session=session)
     testConnClient(connection)
-    assert isinstance(connection.session.serverCertChain, X509CertChain)
-    assert connection.session.serverName == address[0]
-    assert connection.resumed
-    assert connection.encryptThenMAC
+    assert(isinstance(connection.session.serverCertChain, X509CertChain))
+    assert(connection.session.serverName == address[0])
+    assert(connection.resumed)
+    assert(connection.encryptThenMAC)
     connection.close()
 
     print("Test 26.d - resumption with no EtM in 2nd handshake")
@@ -501,10 +501,10 @@ def clientTestCmd(argv):
     connection = connect()
     connection.handshakeClientCert(serverName=address[0])
     testConnClient(connection)
-    assert isinstance(connection.session.serverCertChain, X509CertChain)
-    assert connection.session.serverName == address[0]
-    assert not connection.resumed
-    assert connection.encryptThenMAC
+    assert(isinstance(connection.session.serverCertChain, X509CertChain))
+    assert(connection.session.serverName == address[0])
+    assert(not connection.resumed)
+    assert(connection.encryptThenMAC)
     connection.close()
     session = connection.session
 
@@ -517,7 +517,7 @@ def clientTestCmd(argv):
         connection.handshakeClientCert(serverName=address[0], session=session,
                                        settings=settings)
     except TLSRemoteAlert as e:
-        assert str(e) == "handshake_failure"
+        assert(str(e) == "handshake_failure")
     else:
         raise AssertionError("No exception raised")
     connection.close()
@@ -1009,7 +1009,7 @@ def serverTestCmd(argv):
         connection.handshakeServer(certChain=x509Chain, privateKey=x509Key,
                                    sessionCache=sessionCache)
     except TLSLocalAlert as e:
-        assert str(e) == "handshake_failure"
+        assert(str(e) == "handshake_failure")
     else:
         raise AssertionError("no exception raised")
     connection.close()

--- a/tests/tlstest.py
+++ b/tests/tlstest.py
@@ -117,6 +117,7 @@ def clientTestCmd(argv):
     testConnClient(connection)
     assert(isinstance(connection.session.serverCertChain, X509CertChain))
     assert(connection.session.serverName == address[0])
+    assert connection.encryptThenMAC == True
     connection.close()
 
     print("Test 1.a - good X509, SSLv3")
@@ -448,7 +449,31 @@ def clientTestCmd(argv):
             raise
     connection.close()
 
-    print('Test 26 - good standard XMLRPC https client')
+    print("Test 26.a - no EtM server side")
+    synchro.recv(1)
+    connection = connect()
+    settings = HandshakeSettings()
+    assert settings.useEncryptThenMAC
+    connection.handshakeClientCert(serverName=address[0], settings=settings)
+    testConnClient(connection)
+    assert isinstance(connection.session.serverCertChain, X509CertChain)
+    assert connection.session.serverName == address[0]
+    assert not connection.encryptThenMAC
+    connection.close()
+
+    print("Test 26.b - no EtM client side")
+    synchro.recv(1)
+    connection = connect()
+    settings = HandshakeSettings()
+    settings.useEncryptThenMAC = False
+    connection.handshakeClientCert(serverName=address[0], settings=settings)
+    testConnClient(connection)
+    assert isinstance(connection.session.serverCertChain, X509CertChain)
+    assert connection.session.serverName == address[0]
+    assert not connection.encryptThenMAC
+    connection.close()
+
+    print('Test 27 - good standard XMLRPC https client')
     address = address[0], address[1]+1
     synchro.recv(1)
     try:
@@ -465,7 +490,7 @@ def clientTestCmd(argv):
     synchro.recv(1)
     assert server.pow(2,4) == 16
 
-    print('Test 27 - good tlslite XMLRPC client')
+    print('Test 28 - good tlslite XMLRPC client')
     transport = XMLRPCTransport(ignoreAbruptClose=True)
     server = xmlrpclib.Server('https://%s:%s' % address, transport)
     synchro.recv(1)
@@ -473,22 +498,22 @@ def clientTestCmd(argv):
     synchro.recv(1)
     assert server.pow(2,4) == 16
 
-    print('Test 28 - good XMLRPC ignored protocol')
+    print('Test 29 - good XMLRPC ignored protocol')
     server = xmlrpclib.Server('http://%s:%s' % address, transport)
     synchro.recv(1)
     assert server.add(1,2) == 3
     synchro.recv(1)
     assert server.pow(2,4) == 16
 
-    print("Test 29 - Internet servers test")
+    print("Test 30 - Internet servers test")
     try:
         i = IMAP4_TLS("cyrus.andrew.cmu.edu")
         i.login("anonymous", "anonymous@anonymous.net")
         i.logout()
-        print("Test 30: IMAP4 good")
+        print("Test 31: IMAP4 good")
         p = POP3_TLS("pop.gmail.com")
         p.quit()
-        print("Test 31: POP3 good")
+        print("Test 32: POP3 good")
     except socket.error as e:
         print("Non-critical error: socket error trying to reach internet server: ", e)   
 
@@ -885,7 +910,24 @@ def serverTestCmd(argv):
             raise
     connection.close()
 
-    print("Tests 26-28 - XMLRPXC server")
+    print("Test 26.a - no EtM server side")
+    synchro.send(b'R')
+    connection = connect()
+    settings = HandshakeSettings()
+    settings.useEncryptThenMAC = False
+    connection.handshakeServer(certChain=x509Chain, privateKey=x509Key,
+                               settings=settings)
+    testConnServer(connection)
+    connection.close()
+
+    print("Test 26.b - no EtM client side")
+    synchro.send(b'R')
+    connection = connect()
+    connection.handshakeServer(certChain=x509Chain, privateKey=x509Key)
+    testConnServer(connection)
+    connection.close()
+
+    print("Tests 27-29 - XMLRPXC server")
     address = address[0], address[1]+1
     class Server(TLSXMLRPCServer):
 

--- a/tlslite/constants.py
+++ b/tlslite/constants.py
@@ -44,6 +44,7 @@ class ExtensionType:    # RFC 6066 / 4366
     server_name = 0     # RFC 6066 / 4366
     srp = 12            # RFC 5054  
     cert_type = 9       # RFC 6091
+    encrypt_then_mac = 22 # RFC 7366
     tack = 0xF300
     supports_npn = 13172
     

--- a/tlslite/handshakesettings.py
+++ b/tlslite/handshakesettings.py
@@ -110,6 +110,7 @@ class HandshakeSettings(object):
         self.maxVersion = (3,3)
         self.useExperimentalTackExtension = False
         self.sendFallbackSCSV = False
+        self.useEncryptThenMAC = True
 
     def validate(self):
         """
@@ -130,6 +131,7 @@ class HandshakeSettings(object):
         other.minVersion = self.minVersion
         other.maxVersion = self.maxVersion
         other.sendFallbackSCSV = self.sendFallbackSCSV
+        other.useEncryptThenMAC = self.useEncryptThenMAC
 
         if not cipherfactory.tripleDESPresent:
             other.cipherNames = [e for e in self.cipherNames if e != "3des"]
@@ -179,6 +181,9 @@ class HandshakeSettings(object):
         if other.maxVersion < (3,3):
             # No sha256 pre TLS 1.2
             other.macNames = [e for e in self.macNames if e != "sha256"]
+
+        if other.useEncryptThenMAC not in (True, False):
+            raise ValueError("useEncryptThenMAC can only be True or False")
 
         return other
 

--- a/tlslite/session.py
+++ b/tlslite/session.py
@@ -62,9 +62,9 @@ class Session(object):
         self.encryptThenMAC = False
 
     def create(self, masterSecret, sessionID, cipherSuite,
-            srpUsername, clientCertChain, serverCertChain, 
-            tackExt, tackInHelloExt, serverName, resumable=True,
-            encryptThenMAC=False):
+               srpUsername, clientCertChain, serverCertChain,
+               tackExt, tackInHelloExt, serverName, resumable=True,
+               encryptThenMAC=False):
         self.masterSecret = masterSecret
         self.sessionID = sessionID
         self.cipherSuite = cipherSuite

--- a/tlslite/session.py
+++ b/tlslite/session.py
@@ -41,7 +41,11 @@ class Session(object):
     @ivar tackExt: The server's TackExtension (or None).
 
     @type tackInHelloExt: L{bool}
-    @ivar tackInHelloExt: True if a TACK was presented via TLS Extension.
+    @ivar tackInHelloExt:True if a TACK was presented via TLS Extension.
+
+    @type encryptThenMAC: bool
+    @ivar encryptThenMAC: True if connection uses CBC cipher in
+    encrypt-then-MAC mode
     """
 
     def __init__(self):
@@ -55,10 +59,12 @@ class Session(object):
         self.tackInHelloExt = False
         self.serverName = ""
         self.resumable = False
+        self.encryptThenMAC = False
 
     def create(self, masterSecret, sessionID, cipherSuite,
             srpUsername, clientCertChain, serverCertChain, 
-            tackExt, tackInHelloExt, serverName, resumable=True):
+            tackExt, tackInHelloExt, serverName, resumable=True,
+            encryptThenMAC=False):
         self.masterSecret = masterSecret
         self.sessionID = sessionID
         self.cipherSuite = cipherSuite
@@ -69,6 +75,7 @@ class Session(object):
         self.tackInHelloExt = tackInHelloExt  
         self.serverName = serverName
         self.resumable = resumable
+        self.encryptThenMAC = encryptThenMAC
 
     def _clone(self):
         other = Session()
@@ -82,6 +89,7 @@ class Session(object):
         other.tackInHelloExt = self.tackInHelloExt
         other.serverName = self.serverName
         other.resumable = self.resumable
+        other.encryptThenMAC = self.encryptThenMAC
         return other
 
     def valid(self):

--- a/tlslite/tlsconnection.py
+++ b/tlslite/tlsconnection.py
@@ -424,6 +424,10 @@ class TLSConnection(TLSRecordLayer):
         # (string or None)
         nextProto = self._clientSelectNextProto(nextProtos, serverHello)
 
+        # Check if server selected encrypt-then-MAC
+        if serverHello.getExtension(ExtensionType.encrypt_then_mac):
+            self._recordLayer.encryptThenMAC = True
+
         #If the server elected to resume the session, it is handled here.
         for result in self._clientResume(session, serverHello, 
                         clientHello.random, 
@@ -515,6 +519,13 @@ class TLSConnection(TLSRecordLayer):
 
         #Initialize acceptable certificate types
         certificateTypes = settings.getCertificateTypes()
+
+        #Initialize TLS extensions
+        if settings.useEncryptThenMAC:
+            extensions = [TLSExtension().create(ExtensionType.encrypt_then_mac,
+                                                bytearray(0))]
+        else:
+            extensions = None
             
         #Either send ClientHello (with a resumable session)...
         if session and session.sessionID:
@@ -530,7 +541,8 @@ class TLSConnection(TLSRecordLayer):
                                    certificateTypes, 
                                    session.srpUsername,
                                    reqTack, nextProtos is not None,
-                                   session.serverName)
+                                   session.serverName,
+                                   extensions=extensions)
 
         #Or send ClientHello (without)
         else:
@@ -540,7 +552,8 @@ class TLSConnection(TLSRecordLayer):
                                certificateTypes, 
                                srpUsername,
                                reqTack, nextProtos is not None, 
-                               serverName)
+                               serverName,
+                               extensions=extensions)
         for result in self._sendMsg(clientHello):
             yield result
         yield clientHello
@@ -1149,10 +1162,21 @@ class TLSConnection(TLSRecordLayer):
             tackExt = TackExtension.create(tacks, activationFlags)
         else:
             tackExt = None
+
+        # Prepare other extensions if requested
+        if settings.useEncryptThenMAC and \
+                clientHello.getExtension(ExtensionType.encrypt_then_mac) and \
+                cipherSuite not in CipherSuite.rc4Suites:
+            extensions = [TLSExtension().create(ExtensionType.encrypt_then_mac,
+                                                bytearray(0))]
+            self._recordLayer.encryptThenMAC = True
+        else:
+            extensions = None
+
         serverHello = ServerHello()
         serverHello.create(self.version, getRandomBytes(32), sessionID, \
-                            cipherSuite, CertificateType.x509, tackExt,
-                            nextProtos)
+                           cipherSuite, CertificateType.x509, tackExt,
+                           nextProtos, extensions=extensions)
 
         # Perform the SRP key exchange
         clientCertChain = None

--- a/tlslite/tlsconnection.py
+++ b/tlslite/tlsconnection.py
@@ -492,9 +492,10 @@ class TLSConnection(TLSRecordLayer):
         # Create the session object which is used for resumptions
         self.session = Session()
         self.session.create(masterSecret, serverHello.session_id, cipherSuite,
-            srpUsername, clientCertChain, serverCertChain,
-            tackExt, serverHello.tackExt!=None, serverName,
-            encryptThenMAC=self._recordLayer.encryptThenMAC)
+                            srpUsername, clientCertChain, serverCertChain,
+                            tackExt, (serverHello.tackExt is not None),
+                            serverName,
+                            encryptThenMAC=self._recordLayer.encryptThenMAC)
         self._handshakeDone(resumed=False)
 
 
@@ -1232,9 +1233,10 @@ class TLSConnection(TLSRecordLayer):
         if clientHello.server_name:
             serverName = clientHello.server_name.decode("utf-8")
         self.session.create(masterSecret, serverHello.session_id, cipherSuite,
-            srpUsername, clientCertChain, serverCertChain,
-            tackExt, serverHello.tackExt!=None, serverName,
-            encryptThenMAC=self._recordLayer.encryptThenMAC)
+                            srpUsername, clientCertChain, serverCertChain,
+                            tackExt, (serverHello.tackExt is not None),
+                            serverName,
+                            encryptThenMAC=self._recordLayer.encryptThenMAC)
             
         #Add the session object to the session cache
         if sessionCache and sessionID:
@@ -1339,9 +1341,9 @@ class TLSConnection(TLSRecordLayer):
                 #Send ServerHello
                 if session.encryptThenMAC:
                     self._recordLayer.encryptThenMAC = True
-                    extensions = [TLSExtension().create(
-                                  ExtensionType.encrypt_then_mac,
-                                  bytearray(0))]
+                    mte = TLSExtension().create(ExtensionType.encrypt_then_mac,
+                                                bytearray(0))
+                    extensions = [mte]
                 else:
                     extensions = None
                 serverHello = ServerHello()

--- a/tlslite/tlsrecordlayer.py
+++ b/tlslite/tlsrecordlayer.py
@@ -82,7 +82,7 @@ class TLSRecordLayer(object):
     spurious errors.  The default is False.
 
     @type encryptThenMAC: bool
-    @ivear encryptThenMAC: Whether the connection uses the encrypt-then-MAC
+    @ivar encryptThenMAC: Whether the connection uses the encrypt-then-MAC
     construct for CBC cipher suites, will be False also if connection uses
     RC4 or AEAD.
 

--- a/tlslite/tlsrecordlayer.py
+++ b/tlslite/tlsrecordlayer.py
@@ -81,6 +81,11 @@ class TLSRecordLayer(object):
     attacker truncating the connection, and only if necessary to avoid
     spurious errors.  The default is False.
 
+    @type encryptThenMAC: bool
+    @ivear encryptThenMAC: Whether the connection uses the encrypt-then-MAC
+    construct for CBC cipher suites, will be False also if connection uses
+    RC4 or AEAD.
+
     @sort: __init__, read, readAsync, write, writeAsync, close, closeAsync,
     getCipherImplementation, getCipherName
     """
@@ -147,6 +152,11 @@ class TLSRecordLayer(object):
         protocol version.
         """
         self._recordLayer.version = value
+
+    @property
+    def encryptThenMAC(self):
+        """Whether the connection uses Encrypt Then MAC (RFC 7366)"""
+        return self._recordLayer.encryptThenMAC
 
     def clearReadBuffer(self):
         self._readBuffer = b''

--- a/unit_tests/test_tlslite_handshakesettings.py
+++ b/unit_tests/test_tlslite_handshakesettings.py
@@ -152,3 +152,20 @@ class TestHandshakeSettings(unittest.TestCase):
 
         with self.assertRaises(AssertionError):
             hs.getCertificateTypes()
+
+    def test_useEncryptThenMAC(self):
+        hs = HandshakeSettings()
+        self.assertTrue(hs.useEncryptThenMAC)
+
+        hs.useEncryptThenMAC = False
+
+        n_hs = hs.validate()
+
+        self.assertFalse(n_hs.useEncryptThenMAC)
+
+    def test_useEncryptThenMAC_with_wrong_value(self):
+        hs = HandshakeSettings()
+        hs.useEncryptThenMAC = None
+
+        with self.assertRaises(ValueError):
+            hs.validate()


### PR DESCRIPTION
Implements the encrypt then MAC mechanism for CBC based cipher suites in TLS from RFC 7366.