### PR TITLE
Support for message fragmentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -515,6 +515,8 @@ RFC 7366.
 ===========
 
 0.5.0-alpha - xx/xx/xxxx - Hubert Kario
+ - properly implement record layer fragmentation (previously worked just for
+   Application Data) - RFC 5246 Section 6.2.1
  - Implement RFC 7366 - Encrypt-then-MAC
  - generate minimal padding for CBC ciphers (David Benjamin - Chromium)
  - implementation of `FALLBACK_SCSV` (David Benjamin - Chromium)

--- a/tlslite/defragmenter.py
+++ b/tlslite/defragmenter.py
@@ -1,0 +1,116 @@
+# Copyright (c) 2015, Hubert Kario
+#
+# See the LICENSE file for legal information regarding use of this file.
+
+""" Helper package for handling fragmentation of messages """
+
+from __future__ import generators
+
+from .utils.codec import Parser
+
+class Defragmenter(object):
+
+    """
+    Class for demultiplexing TLS messages.
+
+    Since the messages can be interleaved and fragmented between each other
+    we need to cache not complete ones and return in order of urgency.
+
+    Supports messages with given size (like Alerts) or with a length header
+    in specific place (like Handshake messages).
+
+    @ivar priorities: order in which messages from given types should be
+    returned.
+    @ivar buffers: data buffers for message types
+    @ivar decoders: functions which check buffers if a message of given type
+    is complete
+    """
+
+    def __init__(self):
+        """Set up empty defregmenter"""
+        self.priorities = []
+        self.buffers = {}
+        self.decoders = {}
+
+    def addStaticSize(self, msgType, size):
+        """Add a message type which all messages are of same length"""
+        if msgType in self.priorities:
+            raise ValueError("Message type already defined")
+        if size < 1:
+            raise ValueError("Message size must be positive integer")
+
+        self.priorities += [msgType]
+
+        self.buffers[msgType] = bytearray(0)
+        def sizeHandler(data):
+            """
+            Size of message in parameter
+
+            If complete message is present in parameter returns its size,
+            None otherwise.
+            """
+            if len(data) < size:
+                return None
+            else:
+                return size
+        self.decoders[msgType] = sizeHandler
+
+    def addDynamicSize(self, msgType, sizeOffset, sizeOfSize):
+        """Add a message type which has a dynamic size set in a header"""
+        if msgType in self.priorities:
+            raise ValueError("Message type already defined")
+        if sizeOfSize < 1:
+            raise ValueError("Size of size must be positive integer")
+        if sizeOffset < 0:
+            raise ValueError("Offset can't be negative")
+
+        self.priorities += [msgType]
+        self.buffers[msgType] = bytearray(0)
+
+        def sizeHandler(data):
+            """
+            Size of message in parameter
+
+            If complete message is present in parameter returns its size,
+            None otherwise.
+            """
+            if len(data) < sizeOffset+sizeOfSize:
+                return None
+            else:
+                parser = Parser(data)
+                # skip the header
+                parser.getFixBytes(sizeOffset)
+
+                payloadLength = parser.get(sizeOfSize)
+                if parser.getRemainingLength() < payloadLength:
+                    # not enough bytes in buffer
+                    return None
+                return sizeOffset + sizeOfSize + payloadLength
+
+        self.decoders[msgType] = sizeHandler
+
+    def addData(self, msgType, data):
+        """Adds data to buffers"""
+        if msgType not in self.priorities:
+            raise ValueError("Message type not defined")
+
+        self.buffers[msgType] += data
+
+    def getMessage(self):
+        """Extract the highest priority complete message from buffer"""
+        for msgType in self.priorities:
+            length = self.decoders[msgType](self.buffers[msgType])
+            if length is None:
+                continue
+
+            # extract message
+            data = self.buffers[msgType][:length]
+            # remove it from buffer
+            self.buffers[msgType] = self.buffers[msgType][length:]
+            return (msgType, data)
+        return None
+
+    def clearBuffers(self):
+        """Remove all data from buffers"""
+        for key in self.buffers.keys():
+            self.buffers[key] = bytearray(0)

--- a/tlslite/recordlayer.py
+++ b/tlslite/recordlayer.py
@@ -282,6 +282,13 @@ class RecordLayer(object):
         self._pendingWriteState = ConnectionState()
         self._pendingReadState = ConnectionState()
 
+    def isCBCMode(self):
+        """Returns true if cipher uses CBC mode"""
+        if self._writeState and self._writeState.encContext and \
+                self._writeState.encContext.isBlockCipher:
+            return True
+        else:
+            return False
     #
     # sending messages
     #

--- a/tlslite/recordlayer.py
+++ b/tlslite/recordlayer.py
@@ -310,7 +310,7 @@ class RecordLayer(object):
         return bytearray(mac.digest())
 
     def _macThenEncrypt(self, data, contentType):
-        """MAC then encrypt data"""
+        """MAC, pad then encrypt data"""
         if self._writeState.macContext:
             seqnumBytes = self._writeState.getSeqNumBytes()
             mac = self._writeState.macContext.copy()
@@ -355,9 +355,7 @@ class RecordLayer(object):
 
         return buf
 
-    # randomizeFirstBlock will get used once handling of fragmented
-    # messages is implemented
-    def sendMessage(self, msg, randomizeFirstBlock=True):
+    def sendMessage(self, msg):
         """
         Encrypt, MAC and send message through socket.
 

--- a/tlslite/tlsrecordlayer.py
+++ b/tlslite/tlsrecordlayer.py
@@ -88,6 +88,17 @@ class TLSRecordLayer(object):
     construct for CBC cipher suites, will be False also if connection uses
     RC4 or AEAD.
 
+    @type blockSize: int
+    @ivar blockSize: maimum size of data to be sent in a single record layer
+    message. Note that after encryption is established (generally after
+    handshake protocol has finished) the actual amount of data written to
+    network socket will be larger because of the record layer header, padding
+    or encryption overhead. It can be set to low value (so that there is no
+    fragmentation on Ethernet, IP and TCP level) at the beginning of
+    connection to reduce latency and set to protocol max (2**14) to maximise
+    throughput after sending few kiB of data. Setting to values greater than
+    2**14 will cause the connection to be dropped by RFC compliant peers.
+
     @sort: __init__, read, readAsync, write, writeAsync, close, closeAsync,
     getCipherImplementation, getCipherName
     """
@@ -131,6 +142,9 @@ class TLSRecordLayer(object):
 
         #Fault we will induce, for testing purposes
         self.fault = None
+
+        #Limit the size of outgoing records to following size
+        self.blockSize = 16384 # 2**14
 
     @property
     def _client(self):
@@ -283,23 +297,10 @@ class TLSRecordLayer(object):
             if self.closed:
                 raise TLSClosedConnectionError("attempt to write to closed connection")
 
-            index = 0
-            blockSize = 16384
-            randomizeFirstBlock = True
-            while 1:
-                startIndex = index * blockSize
-                endIndex = startIndex + blockSize
-                if startIndex >= len(s):
-                    break
-                if endIndex > len(s):
-                    endIndex = len(s)
-                block = bytearray(s[startIndex : endIndex])
-                applicationData = ApplicationData().create(block)
-                for result in self._sendMsg(applicationData, \
-                                            randomizeFirstBlock):
-                    yield result
-                randomizeFirstBlock = False #only on 1st message
-                index += 1
+            applicationData = ApplicationData().create(bytearray(s))
+            for result in self._sendMsg(applicationData, \
+                                        randomizeFirstBlock=True):
+                yield result
         except GeneratorExit:
             raise
         except Exception:
@@ -563,6 +564,16 @@ class TLSRecordLayer(object):
             return
             
         contentType = msg.contentType
+
+        #Fragment big messages
+        while len(b) > self.blockSize:
+            newB = b[:self.blockSize]
+            b = b[self.blockSize:]
+
+            msgFragment = Message(contentType, newB)
+            for result in self._sendMsg(msgFragment,
+                                        randomizeFirstBlock=False):
+                yield result
 
         #Update handshake hashes
         if contentType == ContentType.handshake:

--- a/tlslite/tlsrecordlayer.py
+++ b/tlslite/tlsrecordlayer.py
@@ -4,6 +4,7 @@
 #   Google - minimal padding
 #   Martin von Loewis - python 3 port
 #   Yngve Pettersen (ported by Paul Sokolovsky) - TLS 1.2
+#   Hubert Kario
 #
 # See the LICENSE file for legal information regarding use of this file.
 
@@ -18,6 +19,7 @@ from .messages import *
 from .mathtls import *
 from .constants import *
 from .recordlayer import RecordLayer
+from .defragmenter import Defragmenter
 
 import socket
 import traceback
@@ -98,7 +100,10 @@ class TLSRecordLayer(object):
         self.session = None
 
         #Buffers for processing messages
-        self._handshakeBuffer = []
+        self._defragmenter = Defragmenter()
+        self._defragmenter.addStaticSize(ContentType.change_cipher_spec, 1)
+        self._defragmenter.addStaticSize(ContentType.alert, 2)
+        self._defragmenter.addDynamicSize(ContentType.handshake, 1, 3)
         self.clearReadBuffer()
         self.clearWriteBuffer()
 
@@ -589,6 +594,8 @@ class TLSRecordLayer(object):
                 for result in self._getNextRecord():
                     if result in (0, 1):
                         yield result
+                    else:
+                        break
 
                 # Closes the socket
                 self._shutdown(False)
@@ -618,6 +625,8 @@ class TLSRecordLayer(object):
                 for result in self._getNextRecord():
                     if result in (0,1):
                         yield result
+                    else:
+                        break
                 recordHeader, p = result
 
                 #If this is an empty application-data fragment, try again
@@ -762,22 +771,58 @@ class TLSRecordLayer(object):
                                          formatExceptionTrace(e)):
                 yield result
 
-
     #Returns next record or next handshake message
     def _getNextRecord(self):
+        """read next message from socket, defragment message"""
 
-        #If there's a handshake message waiting, return it
-        if self._handshakeBuffer:
-            recordHeader, b = self._handshakeBuffer[0]
-            self._handshakeBuffer = self._handshakeBuffer[1:]
-            yield (recordHeader, Parser(b))
-            return
+        while True:
+            # support for fragmentation
+            # (RFC 5246 Section 6.2.1)
+            # Because the Record Layer is completely separate from the messages
+            # that traverse it, it should handle both application data and
+            # hadshake data in the same way. For that we buffer the handshake
+            # messages until they are completely read.
+            # This makes it possible to handle both handshake data not aligned
+            # to record boundary as well as handshakes longer than single
+            # record.
+            while True:
+                # empty message buffer
+                ret = self._defragmenter.getMessage()
+                if ret is None:
+                    break
+                header = RecordHeader3().create(self.version, ret[0], 0)
+                yield header, Parser(ret[1])
+
+            # when the message buffer is empty, read next record from socket
+            for result in self._getNextRecordFromSocket():
+                if result in (0, 1):
+                    yield result
+                else:
+                    break
+
+            header, parser = result
+
+            # application data isn't made out of messages, pass it through
+            if header.type == ContentType.application_data:
+                yield (header, parser)
+            # If it's an SSLv2 ClientHello, we can return it as well, since
+            # it's the only ssl2 type we support
+            elif header.ssl2:
+                yield (header, parser)
+            else:
+                # other types need to be put into buffers
+                self._defragmenter.addData(header.type, parser.bytes)
+
+    def _getNextRecordFromSocket(self):
+        """Read a record, handle errors"""
 
         try:
+            # otherwise... read the next record
             for result in self._recordLayer.recvMessage():
                 if result in (0, 1):
                     yield result
-                else: break
+                else:
+                    break
         except TLSRecordOverflow:
             for result in self._sendError(AlertDescription.record_overflow):
                 yield result
@@ -794,52 +839,26 @@ class TLSRecordLayer(object):
                     AlertDescription.bad_record_mac,
                     "MAC failure (or padding failure)"):
                 yield result
-        (r, p) = result
-        b = p.bytes
 
-        #Decrypt the record
+        header, parser = result
 
-        #If it doesn't contain handshake messages, we can just return it
-        if r.type != ContentType.handshake:
-            yield (r, p)
-        #If it's an SSLv2 ClientHello, we can return it as well
-        elif r.ssl2:
-            yield (r, p)
-        else:
-            #Otherwise, we loop through and add the handshake messages to the
-            #handshake buffer
-            while 1:
-                if p.index == len(b): #If we're at the end
-                    if not self._handshakeBuffer:
-                        for result in self._sendError(\
-                                AlertDescription.decode_error, \
-                                "Received empty handshake record"):
-                            yield result
-                    break
-                #There needs to be at least 4 bytes to get a header
-                if p.index+4 > len(b):
-                    for result in self._sendError(\
-                            AlertDescription.decode_error,
-                            "A record has a partial handshake message (1)"):
-                        yield result
-                p.get(1) # skip handshake type
-                msgLength = p.get(3)
-                if p.index+msgLength > len(b):
-                    for result in self._sendError(\
-                            AlertDescription.decode_error,
-                            "A record has a partial handshake message (2)"):
-                        yield result
+        # RFC5246 section 5.2.1: Implementations MUST NOT send
+        # zero-length fragments of content types other than Application
+        # Data.
+        if header.type != ContentType.application_data \
+                and parser.getRemainingLength() == 0:
+            for result in self._sendError(\
+                    AlertDescription.decode_error, \
+                    "Received empty non-application data record"):
+                yield result
 
-                handshakePair = (r, b[p.index-4 : p.index+msgLength])
-                self._handshakeBuffer.append(handshakePair)
-                p.index += msgLength
+        if header.type not in ContentType.all:
+            for result in self._sendError(\
+                    AlertDescription.unexpected_message, \
+                    "Received record with unknown ContentType"):
+                yield result
 
-            #We've moved at least one handshake message into the
-            #handshakeBuffer, return the first one
-            recordHeader, b = self._handshakeBuffer[0]
-            self._handshakeBuffer = self._handshakeBuffer[1:]
-            yield (recordHeader, Parser(b))
-
+        yield (header, parser)
 
     def _handshakeStart(self, client):
         if not self.closed:
@@ -848,7 +867,7 @@ class TLSRecordLayer(object):
         self._handshake_md5 = hashlib.md5()
         self._handshake_sha = hashlib.sha1()
         self._handshake_sha256 = hashlib.sha256()
-        self._handshakeBuffer = []
+        self._defragmenter.clearBuffers()
         self.allegedSrpUsername = None
         self._refCount = 1
 

--- a/unit_tests/test_tlslite_defragmenter.py
+++ b/unit_tests/test_tlslite_defragmenter.py
@@ -1,0 +1,256 @@
+# Copyright (c) 2015, Hubert Kario
+#
+# See the LICENSE file for legal information regarding use of this file.
+
+# compatibility with Python 2.6, for that we need unittest2 package,
+# which is not available on 3.3 or 3.4
+try:
+    import unittest2 as unittest
+except ImportError:
+    import unittest
+
+from tlslite.defragmenter import Defragmenter
+
+class TestDefragmenter(unittest.TestCase):
+    def test___init__(self):
+        a = Defragmenter()
+
+        self.assertIsNotNone(a)
+
+    def test_getMessage(self):
+        a = Defragmenter()
+
+        self.assertIsNone(a.getMessage())
+        self.assertIsNone(a.getMessage())
+
+    def test_addStaticSize(self):
+        d = Defragmenter()
+
+        d.addStaticSize(10, 2)
+
+        d.addData(10, bytearray(b'\x03'*2))
+
+        ret = d.getMessage()
+        self.assertIsNotNone(ret)
+        msgType, data = ret
+        self.assertEqual(10, msgType)
+        self.assertEqual(bytearray(b'\x03'*2), data)
+
+    def test_addStaticSize_with_already_defined_type(self):
+        d = Defragmenter()
+
+        d.addStaticSize(10, 255)
+
+        with self.assertRaises(ValueError):
+            d.addStaticSize(10, 2)
+
+    def test_addStaticSize_with_uncomplete_message(self):
+        d = Defragmenter()
+
+        d.addStaticSize(10, 2)
+
+        d.addData(10, bytearray(b'\x10'))
+
+        ret = d.getMessage()
+        self.assertIsNone(ret)
+
+        d.addData(10, bytearray(b'\x11'))
+
+        ret = d.getMessage()
+        self.assertIsNotNone(ret)
+        msgType, data = ret
+        self.assertEqual(10, msgType)
+        self.assertEqual(bytearray(b'\x10\x11'), data)
+
+        ret = d.getMessage()
+        self.assertIsNone(ret)
+
+    def test_addStaticSize_with_multiple_types(self):
+        d = Defragmenter()
+
+        # types are added in order of priority...
+        d.addStaticSize(10, 2)
+        # so type 8 should be returned later than type 10 if both are in buffer
+        d.addStaticSize(8, 4)
+
+        d.addData(8, bytearray(b'\x08'*4))
+        d.addData(10, bytearray(b'\x10'*2))
+
+        ret = d.getMessage()
+        self.assertIsNotNone(ret)
+        msgType, data = ret
+        self.assertEqual(10, msgType)
+        self.assertEqual(bytearray(b'\x10'*2), data)
+
+        ret = d.getMessage()
+        self.assertIsNotNone(ret)
+        msgType, data = ret
+        self.assertEqual(8, msgType)
+        self.assertEqual(bytearray(b'\x08'*4), data)
+
+        ret = d.getMessage()
+        self.assertIsNone(ret)
+
+    def test_addStaticSize_with_multiple_uncompleted_messages(self):
+        d = Defragmenter()
+
+        d.addStaticSize(10, 2)
+        d.addStaticSize(8, 4)
+
+        d.addData(8, bytearray(b'\x08'*3))
+        d.addData(10, bytearray(b'\x10'))
+
+        ret = d.getMessage()
+        self.assertIsNone(ret)
+
+        d.addData(8, bytearray(b'\x09'))
+
+        ret = d.getMessage()
+        self.assertIsNotNone(ret)
+        msgType, data = ret
+        self.assertEqual(8, msgType)
+        self.assertEqual(bytearray(b'\x08'*3 + b'\x09'), data)
+
+        ret = d.getMessage()
+        self.assertIsNone(ret)
+
+    def test_addDynamicSize(self):
+        d = Defragmenter()
+
+        d.addDynamicSize(10, 2, 2)
+
+        ret = d.getMessage()
+        self.assertIsNone(ret)
+
+        d.addData(10, bytearray(
+            b'\xee\xee' +   # header bytes
+            b'\x00\x00' +   # remaining length
+            # next message
+            b'\xff\xff' +   # header bytes
+            b'\x00\x01' +   # remaining length
+            b'\xf0'))
+
+        ret = d.getMessage()
+        self.assertIsNotNone(ret)
+        msgType, data = ret
+        self.assertEqual(10, msgType)
+        self.assertEqual(bytearray(b'\xee\xee\x00\x00'), data)
+
+        ret = d.getMessage()
+        self.assertIsNotNone(ret)
+        msgType, data = ret
+        self.assertEqual(10, msgType)
+        self.assertEqual(bytearray(b'\xff\xff\x00\x01\xf0'), data)
+
+        ret = d.getMessage()
+        self.assertIsNone(ret)
+
+    def test_addDynamicSize_with_incomplete_header(self):
+        d = Defragmenter()
+
+        d.addDynamicSize(10, 2, 2)
+
+        d.addData(10, bytearray(b'\xee'))
+
+        self.assertIsNone(d.getMessage())
+
+        d.addData(10, bytearray(b'\xee'))
+
+        self.assertIsNone(d.getMessage())
+
+        d.addData(10, bytearray(b'\x00'))
+
+        self.assertIsNone(d.getMessage())
+
+        d.addData(10, bytearray(b'\x00'))
+
+        ret = d.getMessage()
+        self.assertIsNotNone(ret)
+        msgType, data = ret
+        self.assertEqual(10, msgType)
+        self.assertEqual(bytearray(b'\xee\xee\x00\x00'), data)
+
+    def test_addDynamicSize_with_incomplete_payload(self):
+        d = Defragmenter()
+
+        d.addDynamicSize(10, 2, 2)
+
+        d.addData(10, bytearray(b'\xee\xee\x00\x01'))
+
+        self.assertIsNone(d.getMessage())
+
+        d.addData(10, bytearray(b'\x99'))
+
+        msgType, data = d.getMessage()
+        self.assertEqual(10, msgType)
+        self.assertEqual(bytearray(b'\xee\xee\x00\x01\x99'), data)
+
+    def test_addDynamicSize_with_two_streams(self):
+        d = Defragmenter()
+
+        d.addDynamicSize(9, 0, 3)
+        d.addDynamicSize(10, 2, 2)
+
+        d.addData(10, bytearray(b'\x44\x44\x00\x04'))
+        d.addData(9, bytearray(b'\x00\x00\x02'))
+
+        self.assertIsNone(d.getMessage())
+
+        d.addData(9, bytearray(b'\x09'*2))
+        d.addData(10, bytearray(b'\x10'*4))
+
+        msgType, data = d.getMessage()
+        self.assertEqual(msgType, 9)
+        self.assertEqual(data, bytearray(b'\x00\x00\x02\x09\x09'))
+
+        msgType, data = d.getMessage()
+        self.assertEqual(msgType, 10)
+        self.assertEqual(data, bytearray(b'\x44'*2 + b'\x00\x04' + b'\x10'*4))
+
+    def test_addStaticSize_with_zero_size(self):
+        d = Defragmenter()
+
+        with self.assertRaises(ValueError):
+            d.addStaticSize(10, 0)
+
+    def test_addStaticSize_with_invalid_size(self):
+        d = Defragmenter()
+
+        with self.assertRaises(ValueError):
+            d.addStaticSize(10, -10)
+
+    def test_addDynamicSize_with_double_type(self):
+        d = Defragmenter()
+
+        d.addDynamicSize(1, 0, 1)
+        with self.assertRaises(ValueError):
+            d.addDynamicSize(1, 2, 2)
+
+    def test_addDynamicSize_with_invalid_size(self):
+        d = Defragmenter()
+
+        with self.assertRaises(ValueError):
+            d.addDynamicSize(1, 2, 0)
+
+    def test_addDynamicSize_with_invalid_offset(self):
+        d = Defragmenter()
+
+        with self.assertRaises(ValueError):
+            d.addDynamicSize(1, -1, 2)
+
+    def test_addData_with_undefined_type(self):
+        d = Defragmenter()
+
+        with self.assertRaises(ValueError):
+            d.addData(1, bytearray(10))
+
+    def test_clearBuffers(self):
+        d = Defragmenter()
+
+        d.addStaticSize(10, 2)
+
+        d.addData(10, bytearray(10))
+
+        d.clearBuffers()
+
+        self.assertIsNone(d.getMessage())

--- a/unit_tests/test_tlslite_recordlayer.py
+++ b/unit_tests/test_tlslite_recordlayer.py
@@ -410,7 +410,7 @@ class TestRecordLayer(unittest.TestCase):
         self.assertIsNotNone(app_data)
         self.assertTrue(len(app_data.write()) > 3)
 
-        for result in recordLayer.sendMessage(app_data, False):
+        for result in recordLayer.sendMessage(app_data):
             if result in (0, 1):
                 self.assertTrue(False, "blocking socket")
             else: break
@@ -452,7 +452,7 @@ class TestRecordLayer(unittest.TestCase):
         self.assertIsNotNone(app_data)
         self.assertTrue(len(app_data.write()) > 3)
 
-        for result in recordLayer.sendMessage(app_data, False):
+        for result in recordLayer.sendMessage(app_data):
             if result in (0, 1):
                 self.assertTrue(False, "blocking socket")
             else: break
@@ -494,7 +494,7 @@ class TestRecordLayer(unittest.TestCase):
         self.assertIsNotNone(app_data)
         self.assertTrue(len(app_data.write()) > 3)
 
-        for result in recordLayer.sendMessage(app_data, False):
+        for result in recordLayer.sendMessage(app_data):
             if result in (0, 1):
                 self.assertTrue(False, "blocking socket")
             else: break
@@ -529,7 +529,7 @@ class TestRecordLayer(unittest.TestCase):
         self.assertIsNotNone(app_data)
         self.assertTrue(len(app_data.write()) > 3)
 
-        for result in recordLayer.sendMessage(app_data, False):
+        for result in recordLayer.sendMessage(app_data):
             if result in (0, 1):
                 self.assertTrue(False, "blocking socket")
             else: break
@@ -563,7 +563,7 @@ class TestRecordLayer(unittest.TestCase):
         self.assertIsNotNone(app_data)
         self.assertTrue(len(app_data.write()) > 3)
 
-        for result in recordLayer.sendMessage(app_data, False):
+        for result in recordLayer.sendMessage(app_data):
             if result in (0, 1):
                 self.assertTrue(False, "blocking socket")
             else: break
@@ -597,7 +597,7 @@ class TestRecordLayer(unittest.TestCase):
         self.assertIsNotNone(app_data)
         self.assertTrue(len(app_data.write()) > 3)
 
-        for result in recordLayer.sendMessage(app_data, False):
+        for result in recordLayer.sendMessage(app_data):
             if result in (0, 1):
                 self.assertTrue(False, "blocking socket")
             else: break
@@ -632,7 +632,7 @@ class TestRecordLayer(unittest.TestCase):
         self.assertIsNotNone(app_data)
         self.assertTrue(len(app_data.write()) > 3)
 
-        for result in recordLayer.sendMessage(app_data, False):
+        for result in recordLayer.sendMessage(app_data):
             if result in (0, 1):
                 self.assertTrue(False, "blocking socket")
             else: break
@@ -669,7 +669,7 @@ class TestRecordLayer(unittest.TestCase):
         self.assertIsNotNone(app_data)
         self.assertTrue(len(app_data.write()) > 3)
 
-        for result in recordLayer.sendMessage(app_data, False):
+        for result in recordLayer.sendMessage(app_data):
             if result in (0, 1):
                 self.assertTrue(False, "blocking socket")
             else: break
@@ -703,7 +703,7 @@ class TestRecordLayer(unittest.TestCase):
         self.assertIsNotNone(app_data)
         self.assertTrue(len(app_data.write()) > 3)
 
-        for result in recordLayer.sendMessage(app_data, False):
+        for result in recordLayer.sendMessage(app_data):
             if result in (0, 1):
                 self.assertTrue(False, "blocking socket")
             else: break

--- a/unit_tests/test_tlslite_recordlayer.py
+++ b/unit_tests/test_tlslite_recordlayer.py
@@ -329,6 +329,7 @@ class TestRecordLayer(unittest.TestCase):
 
         self.assertIsNone(recordLayer.getCipherName())
         self.assertIsNone(recordLayer.getCipherImplementation())
+        self.assertFalse(recordLayer.isCBCMode())
 
     def test_sendMessage(self):
         sock = MockSocket(bytearray(0))
@@ -365,6 +366,7 @@ class TestRecordLayer(unittest.TestCase):
         recordLayer.changeWriteState()
 
         self.assertEqual('aes128', recordLayer.getCipherName())
+        self.assertTrue(recordLayer.isCBCMode())
 
     def test_getCipherImplementation(self):
         sock = MockSocket(bytearray(0))

--- a/unit_tests/test_tlslite_tlsrecordlayer.py
+++ b/unit_tests/test_tlslite_tlsrecordlayer.py
@@ -370,18 +370,17 @@ class TestTLSRecordLayer(unittest.TestCase):
 
         gen = record_layer._sendMsg(client_hello)
 
-        # XXX should not happen, client hello messages larger than record
-        # layer maximum fragment size should get fragmented
-        with self.assertRaises(ValueError):
-            next(gen)
+        for result in gen:
+            if result in (0, 1):
+                self.assertTrue(False, "blocking")
+            else:
+                break
 
-        return
-
-        send_arg = mock_sock.send.call_args_list[0]
         # The maximum length that can be sent in single record is 2**14
         # record layer adds 5 byte on top of that
-        self.assertTrue(len(send_arg[0][0]) <= 2**14 + 5)
-        self.assertEqual(2, mock_sock.send.call_count)
+        self.assertEqual(len(mock_sock.sent), 5)
+        for msg in mock_sock.sent:
+            self.assertTrue(len(msg) <= 2**14 + 5)
 
     def test__getMsg(self):
 

--- a/unit_tests/test_tlslite_tlsrecordlayer.py
+++ b/unit_tests/test_tlslite_tlsrecordlayer.py
@@ -18,9 +18,19 @@ except ImportError:
 import socket
 import errno
 from tlslite.tlsrecordlayer import TLSRecordLayer
-from tlslite.constants import ContentType
-from tlslite.errors import TLSAbruptCloseError, TLSLocalAlert
-from tlslite.messages import Message
+from tlslite.messages import Message, ClientHello, ServerHello, Certificate, \
+        ServerHelloDone, ClientKeyExchange, ChangeCipherSpec, Finished, \
+        RecordHeader3
+from tlslite.errors import TLSAbruptCloseError, TLSLocalAlert, \
+        TLSAbruptCloseError
+from tlslite.extensions import TLSExtension
+from tlslite.constants import ContentType, HandshakeType, CipherSuite, \
+        CertificateType
+from tlslite.mathtls import calcMasterSecret, PRF_1_2
+from tlslite.x509 import X509
+from tlslite.x509certchain import X509CertChain
+from tlslite.utils.keyfactory import parsePEMKey
+from tlslite.utils.codec import Parser
 from unit_tests.mocksock import MockSocket
 
 class TestTLSRecordLayer(unittest.TestCase):
@@ -239,6 +249,82 @@ class TestTLSRecordLayer(unittest.TestCase):
 
         self.assertEqual(0, result)
 
+    def test__getNextRecord_with_empty_handshake(self):
+
+        mock_sock = MockSocket(bytearray(
+            b'\x16' +           # handshake
+            b'\x03\x03' +       # TLSv1.2
+            b'\x00\x00'         # length
+            ))
+
+        record_layer = TLSRecordLayer(mock_sock)
+
+        with self.assertRaises(TLSLocalAlert):
+            for result in record_layer._getNextRecord():
+                if result in (0,1):
+                    raise Exception("blocking socket")
+                else:
+                    break
+
+    def test__getNextRecord_with_multiple_messages_in_single_record(self):
+
+        mock_sock = MockSocket(bytearray(
+            b'\x16' +           # handshake
+            b'\x03\x03' +       # TLSv1.2
+            b'\x00\x35' +       # length
+            # server hello
+            b'\x02' +           # type - server hello
+            b'\x00\x00\x26' +   # length
+            b'\x03\x03' +       # TLSv1.2
+            b'\x01'*32 +        # random
+            b'\x00' +           # session ID length
+            b'\x00\x2f' +       # cipher suite selected
+            b'\x00' +           # compression method
+            # certificate
+            b'\x0b' +           # type - certificate
+            b'\x00\x00\x03'     # length
+            b'\x00\x00\x00'     # length of certificates
+            # server hello done
+            b'\x0e' +           # type - server hello done
+            b'\x00\x00\x00'     # length
+            ))
+
+        record_layer = TLSRecordLayer(mock_sock)
+
+        results = []
+        for result in record_layer._getNextRecord():
+            if result in (0,1):
+                raise Exception("blocking")
+            else:
+                results.append(result)
+                if len(results) == 3:
+                    break
+
+        header, p = results[0]
+
+        self.assertIsInstance(header, RecordHeader3)
+        self.assertEqual(ContentType.handshake, header.type)
+        self.assertEqual(42, len(p.bytes))
+        self.assertEqual(HandshakeType.server_hello, p.bytes[0])
+
+        # XXX generator stops as soon as a message was read
+        self.assertEqual(1, len(results))
+        return
+
+        header, p = results[1]
+
+        self.assertIsInstance(header, RecordHeader3)
+        self.assertEqual(ContentType.handshake, header.type)
+        self.assertEqual(7, len(p.bytes))
+        self.assertEqual(HandshakeType.certificate, p.bytes[0])
+
+        header, p = results[2]
+
+        self.assertIsInstance(header, RecordHeader3)
+        self.assertEqual(ContentType.handshake, header.type)
+        self.assertEqual(4, len(p.bytes))
+        self.assertEqual(HandshakeType.server_hello_done, p.bytes[0])
+
     def test__sendMsg(self):
         mockSock = MockSocket(bytearray(0))
         sock = TLSRecordLayer(mockSock)
@@ -293,3 +379,568 @@ class TestTLSRecordLayer(unittest.TestCase):
 
         with self.assertRaises(TLSAbruptCloseError):
             next(gen)
+
+    def test__sendMsg_with_large_message(self):
+
+        mock_sock = MockSocket(bytearray(0))
+
+        record_layer = TLSRecordLayer(mock_sock)
+
+        client_hello = ClientHello().create((3,3), bytearray(32), bytearray(0),
+                [x for x in range(2**15-1)])
+
+        gen = record_layer._sendMsg(client_hello)
+
+        # XXX should not happen, client hello messages larger than record
+        # layer maximum fragment size should get fragmented
+        with self.assertRaises(ValueError):
+            next(gen)
+
+        return
+
+        send_arg = mock_sock.send.call_args_list[0]
+        # The maximum length that can be sent in single record is 2**14
+        # record layer adds 5 byte on top of that
+        self.assertTrue(len(send_arg[0][0]) <= 2**14 + 5)
+        self.assertEqual(2, mock_sock.send.call_count)
+
+    def test__getMsg(self):
+
+        mock_sock = MockSocket(
+                bytearray(
+                b'\x16' +           # handshake
+                b'\x03\x03' +       # TLSv1.2
+                b'\x00\x3a' +       # payload length
+                b'\x02' +           # Server Hello
+                b'\x00\x00\x36' +   # hello length
+                b'\x03\x03' +       # TLSv1.2
+                b'\x00'*32 +        # random
+                b'\x00' +           # session ID length
+                b'\x00\x2f' +       # cipher suite selected (AES128-SHA)
+                b'\x00' +           # compression null
+                b'\x00\x0e' +       # extensions length
+                b'\xff\x01' +       # renegotiation_info
+                b'\x00\x01' +       # ext length
+                b'\x00' +           # renegotiation info ext length - 0
+                b'\x00\x23' +       # session_ticket
+                b'\x00\x00' +       # ext length
+                b'\x00\x0f' +       # heartbeat extension
+                b'\x00\x01' +       # ext length
+                b'\x01'))           # peer is allowed to send requests
+
+        record_layer = TLSRecordLayer(mock_sock)
+
+        gen = record_layer._getMsg(ContentType.handshake,
+                HandshakeType.server_hello)
+
+        message = next(gen)
+
+        self.assertEqual(ServerHello, type(message))
+        self.assertEqual((3,3), message.server_version)
+        self.assertEqual(0x002f, message.cipher_suite)
+
+    def test__getMsg_with_fragmented_message(self):
+
+        mock_sock = MockSocket(
+                bytearray(
+                b'\x16' +           # handshake
+                b'\x03\x03' +       # TLSv1.2
+                b'\x00\x06' +       # payload length
+                b'\x02' +           # Server Hello
+                b'\x00\x00\x36' +   # hello length
+                b'\x03\x03' +       # TLSv1.2
+                # fragment end
+                b'\x16' +           # type - handshake
+                b'\x03\x03' +       # TLSv1.2
+                b'\x00\x34' +       # payload length:
+                b'\x00'*32 +        # random
+                b'\x00' +           # session ID length
+                b'\x00\x2f' +       # cipher suite selected (AES128-SHA)
+                b'\x00' +           # compression null
+                b'\x00\x0e' +       # extensions length
+                b'\xff\x01' +       # renegotiation_info
+                b'\x00\x01' +       # ext length
+                b'\x00' +           # renegotiation info ext length - 0
+                b'\x00\x23' +       # session_ticket
+                b'\x00\x00' +       # ext length
+                b'\x00\x0f' +       # heartbeat extension
+                b'\x00\x01' +       # ext length
+                b'\x01'))           # peer is allowed to send requests
+
+        record_layer = TLSRecordLayer(mock_sock)
+
+        gen = record_layer._getMsg(ContentType.handshake,
+                HandshakeType.server_hello)
+
+        # XXX record layer doesn't handle fragmented hello messages
+        with self.assertRaises(TLSLocalAlert):
+            message = next(gen)
+
+        return
+
+        if message in (0,1):
+            raise Exception("blocking")
+
+        self.assertEqual(ServerHello, type(message))
+        self.assertEqual((3,3), message.server_version)
+        self.assertEqual(0x002f, message.cipher_suite)
+
+    def test__getMsg_with_oversized_message(self):
+
+        mock_sock = MockSocket(
+                bytearray(
+                b'\x16' +           # handshake
+                b'\x03\x03' +       # TLSv1.2
+                b'\x40\x01' +       # payload length 2**14+1
+                b'\x02' +           # Server Hello
+                b'\x00\x3f\xfd' +   # hello length 2**14+1-1-3
+                b'\x03\x03' +       # TLSv1.2
+                b'\x00'*32 +        # random
+                b'\x00' +           # session ID length
+                b'\x00\x2f' +       # cipher suite selected (AES128-SHA)
+                b'\x00' +           # compression null
+                b'\x3f\xd5' +       # extensions length: 2**14+1-1-3-2-32-6
+                b'\xff\xff' +       # extension type (padding)
+                b'\x3f\xd1' +       # extension length: 2**14+1-1-3-2-32-6-4
+                b'\x00'*16337       # value
+                ))
+
+        record_layer = TLSRecordLayer(mock_sock)
+
+        gen = record_layer._getMsg(ContentType.handshake,
+                HandshakeType.server_hello)
+
+        # XXX decoder handles messages over the 2**14 limit!
+        # with self.assertRaises(TLSLocalAlert):
+        message = next(gen)
+
+    #
+    # Temporary tests below
+    #
+
+    def test_full_connection_with_RSA_kex(self):
+
+        clnt_sock, srv_sock = socket.socketpair()
+
+        #
+        # client part
+        #
+        record_layer = TLSRecordLayer(clnt_sock)
+
+        record_layer._handshakeStart(client=True)
+        record_layer.version = (3,3)
+
+        client_hello = ClientHello()
+        client_hello = client_hello.create((3,3), bytearray(32),
+                bytearray(0), [CipherSuite.TLS_RSA_WITH_AES_128_CBC_SHA],
+                None, None, False, False, None)
+
+        for result in record_layer._sendMsg(client_hello):
+            if result in (0,1):
+                raise Exception("blocking socket")
+
+        #
+        # server part
+        #
+
+        srv_record_layer = TLSRecordLayer(srv_sock)
+
+        srv_raw_certificate = str(
+            "-----BEGIN CERTIFICATE-----\n"\
+            "MIIB9jCCAV+gAwIBAgIJAMyn9DpsTG55MA0GCSqGSIb3DQEBCwUAMBQxEjAQBgNV\n"\
+            "BAMMCWxvY2FsaG9zdDAeFw0xNTAxMjExNDQzMDFaFw0xNTAyMjAxNDQzMDFaMBQx\n"\
+            "EjAQBgNVBAMMCWxvY2FsaG9zdDCBnzANBgkqhkiG9w0BAQEFAAOBjQAwgYkCgYEA\n"\
+            "0QkEeakSyV/LMtTeARdRtX5pdbzVuUuqOIdz3lg7YOyRJ/oyLTPzWXpKxr//t4FP\n"\
+            "QvYsSJiVOlPk895FNu6sNF/uJQyQGfFWYKkE6fzFifQ6s9kssskFlL1DVI/dD/Zn\n"\
+            "7sgzua2P1SyLJHQTTs1MtMb170/fX2EBPkDz+2kYKN0CAwEAAaNQME4wHQYDVR0O\n"\
+            "BBYEFJtvXbRmxRFXYVMOPH/29pXCpGmLMB8GA1UdIwQYMBaAFJtvXbRmxRFXYVMO\n"\
+            "PH/29pXCpGmLMAwGA1UdEwQFMAMBAf8wDQYJKoZIhvcNAQELBQADgYEAkOgC7LP/\n"\
+            "Rd6uJXY28HlD2K+/hMh1C3SRT855ggiCMiwstTHACGgNM+AZNqt6k8nSfXc6k1gw\n"\
+            "5a7SGjzkWzMaZC3ChBeCzt/vIAGlMyXeqTRhjTCdc/ygRv3NPrhUKKsxUYyXRk5v\n"\
+            "g/g6MwxzXfQP3IyFu3a9Jia/P89Z1rQCNRY=\n"\
+            "-----END CERTIFICATE-----\n"\
+            )
+
+        srv_raw_key = str(
+            "-----BEGIN RSA PRIVATE KEY-----\n"\
+            "MIICXQIBAAKBgQDRCQR5qRLJX8sy1N4BF1G1fml1vNW5S6o4h3PeWDtg7JEn+jIt\n"\
+            "M/NZekrGv/+3gU9C9ixImJU6U+Tz3kU27qw0X+4lDJAZ8VZgqQTp/MWJ9Dqz2Syy\n"\
+            "yQWUvUNUj90P9mfuyDO5rY/VLIskdBNOzUy0xvXvT99fYQE+QPP7aRgo3QIDAQAB\n"\
+            "AoGAVSLbE8HsyN+fHwDbuo4I1Wa7BRz33xQWLBfe9TvyUzOGm0WnkgmKn3LTacdh\n"\
+            "GxgrdBZXSun6PVtV8I0im5DxyVaNdi33sp+PIkZU386f1VUqcnYnmgsnsUQEBJQu\n"\
+            "fUZmgNM+bfR+Rfli4Mew8lQ0sorZ+d2/5fsM0g80Qhi5M3ECQQDvXeCyrcy0u/HZ\n"\
+            "FNjIloyXaAIvavZ6Lc6gfznCSfHc5YwplOY7dIWp8FRRJcyXkA370l5dJ0EXj5Gx\n"\
+            "udV9QQ43AkEA34+RxjRk4DT7Zo+tbM/Fkoi7jh1/0hFkU5NDHweJeH/mJseiHtsH\n"\
+            "KOcPGtEGBBqT2KNPWVz4Fj19LiUmmjWXiwJBAIBs49O5/+ywMdAAqVblv0S0nweF\n"\
+            "4fwne4cM+5ZMSiH0XsEojGY13EkTEon/N8fRmE8VzV85YmkbtFWgmPR85P0CQQCs\n"\
+            "elWbN10EZZv3+q1wH7RsYzVgZX3yEhz3JcxJKkVzRCnKjYaUi6MweWN76vvbOq4K\n"\
+            "G6Tiawm0Duh/K4ZmvyYVAkBppE5RRQqXiv1KF9bArcAJHvLm0vnHPpf1yIQr5bW6\n"\
+            "njBuL4qcxlaKJVGRXT7yFtj2fj0gv3914jY2suWqp8XJ\n"\
+            "-----END RSA PRIVATE KEY-----\n"\
+            )
+
+        srv_private_key = parsePEMKey(srv_raw_key, private=True)
+        srv_cert_chain = X509CertChain([X509().parse(srv_raw_certificate)])
+
+        srv_record_layer._handshakeStart(client=False)
+
+        srv_record_layer.version = (3,3)
+
+        for result in srv_record_layer._getMsg(ContentType.handshake,
+                HandshakeType.client_hello):
+            if result in (0,1):
+                raise Exception("blocking socket")
+            else:
+                break
+
+        srv_client_hello = result
+        self.assertEqual(ClientHello, type(srv_client_hello))
+
+        srv_cipher_suite = CipherSuite.TLS_RSA_WITH_AES_128_CBC_SHA
+        srv_session_id = bytearray(0)
+
+        srv_server_hello = ServerHello().create(
+                (3,3), bytearray(32), srv_session_id, srv_cipher_suite,
+                CertificateType.x509, None, None)
+
+        srv_msgs = []
+        srv_msgs.append(srv_server_hello)
+        srv_msgs.append(Certificate(CertificateType.x509).
+                create(srv_cert_chain))
+        srv_msgs.append(ServerHelloDone())
+        for result in srv_record_layer._sendMsgs(srv_msgs):
+            if result in (0,1):
+                raise Exception("blocking socket")
+            else:
+                break
+        srv_record_layer._versionCheck = True
+
+        #
+        # client part
+        #
+
+        for result in record_layer._getMsg(ContentType.handshake,
+                HandshakeType.server_hello):
+            if result in (0,1):
+                raise Exception("blocking socket")
+            else:
+                break
+
+        server_hello = result
+        self.assertEqual(ServerHello, type(server_hello))
+
+        for result in record_layer._getMsg(ContentType.handshake,
+                HandshakeType.certificate, CertificateType.x509):
+            if result in (0,1):
+                raise Exception("blocking socket")
+            else:
+                break
+
+        server_certificate = result
+        self.assertEqual(Certificate, type(server_certificate))
+
+        for result in record_layer._getMsg(ContentType.handshake,
+                HandshakeType.server_hello_done):
+            if result in (0,1):
+                raise Exception("blocking socket")
+            else:
+                break
+
+        server_hello_done = result
+        self.assertEqual(ServerHelloDone, type(server_hello_done))
+
+        public_key = server_certificate.certChain.getEndEntityPublicKey()
+
+        premasterSecret = bytearray(48)
+        premasterSecret[0] = 3 # 'cause we negotiatied TLSv1.2
+        premasterSecret[1] = 3
+
+        encryptedPreMasterSecret = public_key.encrypt(premasterSecret)
+
+        client_key_exchange = ClientKeyExchange(
+                CipherSuite.TLS_RSA_WITH_AES_128_CBC_SHA,
+                (3,3))
+        client_key_exchange.createRSA(encryptedPreMasterSecret)
+
+        for result in record_layer._sendMsg(client_key_exchange):
+            if result in (0,1):
+                raise Exception("blocking socket")
+            else:
+                break
+
+        master_secret = calcMasterSecret((3,3), premasterSecret,
+                client_hello.random, server_hello.random)
+
+        record_layer._calcPendingStates(
+                CipherSuite.TLS_RSA_WITH_AES_128_CBC_SHA,
+                master_secret, client_hello.random, server_hello.random,
+                None)
+
+        for result in record_layer._sendMsg(ChangeCipherSpec()):
+            if result in (0,1):
+                raise Exception("blocking socket")
+            else:
+                break
+
+        record_layer._changeWriteState()
+
+        handshake_hashes = record_layer._handshake_sha256.digest()
+        verify_data = PRF_1_2(master_secret, b'client finished',
+                handshake_hashes, 12)
+
+        finished = Finished((3,3)).create(verify_data)
+        for result in record_layer._sendMsg(finished):
+            if result in (0,1):
+                raise Exception("blocking socket")
+            else:
+                break
+
+        #
+        # server part
+        #
+
+        for result in srv_record_layer._getMsg(ContentType.handshake,
+                HandshakeType.client_key_exchange,
+                srv_cipher_suite):
+            if result in (0,1):
+                raise Exception("blocking socket")
+            else:
+                break
+
+        srv_client_key_exchange = result
+
+        srv_premaster_secret = srv_private_key.decrypt(
+                srv_client_key_exchange.encryptedPreMasterSecret)
+
+        self.assertEqual(bytearray(b'\x03\x03' + b'\x00'*46),
+                srv_premaster_secret)
+
+        srv_master_secret = calcMasterSecret(srv_record_layer.version,
+                srv_premaster_secret, srv_client_hello.random,
+                srv_server_hello.random)
+
+        srv_record_layer._calcPendingStates(srv_cipher_suite,
+                srv_master_secret, srv_client_hello.random,
+                srv_server_hello.random, None)
+
+        for result in srv_record_layer._getMsg(ContentType.change_cipher_spec):
+            if result in (0,1):
+                raise Exception("blocking socket")
+            else:
+                break
+
+        srv_change_cipher_spec = result
+        self.assertEqual(ChangeCipherSpec, type(srv_change_cipher_spec))
+
+        srv_record_layer._changeReadState()
+
+        srv_handshakeHashes = srv_record_layer._handshake_sha256.digest()
+        srv_verify_data = PRF_1_2(srv_master_secret, b"client finished",
+                srv_handshakeHashes, 12)
+
+        for result in srv_record_layer._getMsg(ContentType.handshake,
+                HandshakeType.finished):
+            if result in (0,1):
+                raise Exception("blocking socket")
+            else:
+                break
+        srv_finished = result
+        self.assertEqual(Finished, type(srv_finished))
+        self.assertEqual(srv_verify_data, srv_finished.verify_data)
+
+        for result in srv_record_layer._sendMsg(ChangeCipherSpec()):
+            if result in (0,1):
+                raise Exception("blocking socket")
+            else:
+                break
+
+        srv_record_layer._changeWriteState()
+
+        srv_handshakeHashes = srv_record_layer._handshake_sha256.digest()
+        srv_verify_data = PRF_1_2(srv_master_secret, b"server finished",
+                srv_handshakeHashes, 12)
+
+        for result in srv_record_layer._sendMsg(Finished((3,3)).create(
+                srv_verify_data)):
+            if result in (0,1):
+                raise Exception("blocking socket")
+            else:
+                break
+
+        srv_record_layer._handshakeDone(resumed=False)
+
+        #
+        # client part
+        #
+
+        for result in record_layer._getMsg(ContentType.change_cipher_spec):
+            if result in (0,1):
+                raise Exception("blocking socket")
+            else:
+                break
+
+        change_cipher_spec = result
+        self.assertEqual(ChangeCipherSpec, type(change_cipher_spec))
+
+        record_layer._changeReadState()
+
+        handshake_hashes = record_layer._handshake_sha256.digest()
+        server_verify_data = PRF_1_2(master_secret, b'server finished',
+                handshake_hashes, 12)
+
+        for result in record_layer._getMsg(ContentType.handshake,
+                HandshakeType.finished):
+            if result in (0,1):
+                raise Exception("blocking socket")
+            else:
+                break
+
+        server_finished = result
+        self.assertEqual(Finished, type(server_finished))
+        self.assertEqual(server_verify_data, server_finished.verify_data)
+
+        record_layer._handshakeDone(resumed=False)
+
+        # try sending data
+        record_layer.write(bytearray(b'text\n'))
+
+        # try recieving data
+        data = srv_record_layer.read(10)
+        self.assertEqual(data, bytearray(b'text\n'))
+
+        record_layer.close()
+        srv_record_layer.close()
+
+    @unittest.skip("needs external TLS server")
+    def test_full_connection_with_external_server(self):
+
+        # TODO test is slow (100ms) move to integration test suite
+        #
+        # start a regular TLS server locally before running this test
+        # e.g.: openssl s_server -key localhost.key -cert localhost.crt
+
+        sock = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
+        sock.connect(("127.0.0.1", 4433))
+
+        record_layer = TLSRecordLayer(sock)
+
+        record_layer._handshakeStart(client=True)
+        record_layer.version = (3,3)
+
+        client_hello = ClientHello()
+        client_hello = client_hello.create((3,3), bytearray(32),
+                bytearray(0), [CipherSuite.TLS_RSA_WITH_AES_128_CBC_SHA],
+                None, None, False, False, None)
+
+        for result in record_layer._sendMsg(client_hello):
+            if result in (0,1):
+                raise Exception("blocking socket")
+
+        for result in record_layer._getMsg(ContentType.handshake,
+                HandshakeType.server_hello):
+            if result in (0,1):
+                raise Exception("blocking socket")
+            else:
+                break
+
+        server_hello = result
+        self.assertEqual(ServerHello, type(server_hello))
+
+        for result in record_layer._getMsg(ContentType.handshake,
+                HandshakeType.certificate, CertificateType.x509):
+            if result in (0,1):
+                raise Exception("blocking socket")
+            else:
+                break
+
+        server_certificate = result
+        self.assertEqual(Certificate, type(server_certificate))
+
+        for result in record_layer._getMsg(ContentType.handshake,
+                HandshakeType.server_hello_done):
+            if result in (0,1):
+                raise Exception("blocking socket")
+            else:
+                break
+
+        server_hello_done = result
+        self.assertEqual(ServerHelloDone, type(server_hello_done))
+
+        public_key = server_certificate.certChain.getEndEntityPublicKey()
+
+        premasterSecret = bytearray(48)
+        premasterSecret[0] = 3 # 'cause we negotiatied TLSv1.2
+        premasterSecret[1] = 3
+
+        encryptedPreMasterSecret = public_key.encrypt(premasterSecret)
+
+        client_key_exchange = ClientKeyExchange(
+                CipherSuite.TLS_RSA_WITH_AES_128_CBC_SHA,
+                (3,3))
+        client_key_exchange.createRSA(encryptedPreMasterSecret)
+
+        for result in record_layer._sendMsg(client_key_exchange):
+            if result in (0,1):
+                raise Exception("blocking socket")
+            else:
+                break
+
+        master_secret = calcMasterSecret((3,3), premasterSecret,
+                client_hello.random, server_hello.random)
+
+        record_layer._calcPendingStates(
+                CipherSuite.TLS_RSA_WITH_AES_128_CBC_SHA,
+                master_secret, client_hello.random, server_hello.random,
+                None)
+
+        for result in record_layer._sendMsg(ChangeCipherSpec()):
+            if result in (0,1):
+                raise Exception("blocking socket")
+            else:
+                break
+
+        record_layer._changeWriteState()
+
+        handshake_hashes = record_layer._handshake_sha256.digest()
+        verify_data = PRF_1_2(master_secret, b'client finished',
+                handshake_hashes, 12)
+
+        finished = Finished((3,3)).create(verify_data)
+        for result in record_layer._sendMsg(finished):
+            if result in (0,1):
+                raise Exception("blocking socket")
+            else:
+                break
+
+        for result in record_layer._getMsg(ContentType.change_cipher_spec):
+            if result in (0,1):
+                raise Exception("blocking socket")
+            else:
+                break
+
+        change_cipher_spec = result
+        self.assertEqual(ChangeCipherSpec, type(change_cipher_spec))
+
+        record_layer._changeReadState()
+
+        handshake_hashes = record_layer._handshake_sha256.digest()
+        server_verify_data = PRF_1_2(master_secret, b'server finished',
+                handshake_hashes, 12)
+
+        for result in record_layer._getMsg(ContentType.handshake,
+                HandshakeType.finished):
+            if result in (0,1):
+                raise Exception("blocking socket")
+            else:
+                break
+
+        server_finished = result
+        self.assertEqual(Finished, type(server_finished))
+        self.assertEqual(server_verify_data, server_finished.verify_data)
+
+        record_layer._handshakeDone(resumed=False)
+
+        record_layer.write(bytearray(b'text\n'))
+
+        record_layer.close()
+


### PR DESCRIPTION
Implement RFC 5246 Section 6.2.1

Fragment writes that are above the 2^14 byte limit to smaller Record Layer messages (previously that was the case only for Application Data, now it applies to Handshake protocol too)

Support reading of fragmented messages and multiple messages of same type in single Record Layer message.