### PR TITLE
Clean up CipherSuite, CKE, SKE

### DIFF
--- a/README.md
+++ b/README.md
@@ -515,6 +515,7 @@ RFC 7366.
 ===========
 
 0.5.0-alpha - xx/xx/xxxx - Hubert Kario
+ - fix SRP_SHA_RSA ciphersuites
  - properly implement record layer fragmentation (previously worked just for
    Application Data) - RFC 5246 Section 6.2.1
  - Implement RFC 7366 - Encrypt-then-MAC

--- a/tlslite/constants.py
+++ b/tlslite/constants.py
@@ -112,42 +112,106 @@ class AlertDescription:
 
 
 class CipherSuite:
+
+    """
+    Numeric values of ciphersuites and ciphersuite types
+
+    @cvar tripleDESSuites: ciphersuties which use 3DES symmetric cipher in CBC
+    mode
+    @cvar aes128Suites: ciphersuites which use AES symmetric cipher in CBC mode
+    with 128 bit key
+    @cvar aes256Suites: ciphersuites which use AES symmetric cipher in CBC mode
+    with 128 bit key
+    @cvar rc4Suites: ciphersuites which use RC4 symmetric cipher with 128 bit
+    key
+    @cvar shaSuites: ciphersuites which use SHA-1 HMAC integrity mechanism
+    and protocol default Pseudo Random Function
+    @cvar sha256Suites: ciphersuites which use SHA-256 HMAC integrity mechanism
+    and SHA-256 Pseudo Random Function
+    @cvar md5Suites: ciphersuites which use MD-5 HMAC integrity mechanism and
+    protocol default Pseudo Random Function
+    @cvar srpSuites: ciphersuites which use Secure Remote Password (SRP) key
+    exchange protocol
+    @cvar srpCertSuites: ciphersuites which use Secure Remote Password (SRP)
+    key exchange protocol with RSA server authentication
+    @cvar srpAllSuites: all SRP ciphersuites, pure SRP and with RSA based
+    server authentication
+    @cvar certSuites: ciphersuites which use RSA key exchange with RSA server
+    authentication
+    @cvar certAllSuites: ciphersuites which use RSA server authentication
+    @cvar anonSuites: ciphersuites which use anonymous Finite Field
+    Diffie-Hellman key exchange
+    @cvar ietfNames: dictionary with string names of the ciphersuites
+    """
+
+    ietfNames = {}
+
     # Weird pseudo-ciphersuite from RFC 5746
     # Signals that "secure renegotiation" is supported
     # We actually don't do any renegotiation, but this
     # prevents renegotiation attacks
     TLS_EMPTY_RENEGOTIATION_INFO_SCSV = 0x00FF
+    ietfNames[0x00FF] = 'TLS_EMPTY_RENEGOTIATION_INFO_SCSV'
 
-    # draft-ietf-tls-downgrade-scsv-03
+    # RFC 7507 - Fallback Signaling Cipher Suite Value for Preventing Protocol
+    # Downgrade Attacks
     TLS_FALLBACK_SCSV = 0x5600
+    ietfNames[0x5600] = 'TLS_FALLBACK_SCSV'
     
+    # RFC 5054 - Secure Remote Password (SRP) Protocol for TLS Authentication
     TLS_SRP_SHA_WITH_3DES_EDE_CBC_SHA  = 0xC01A
+    ietfNames[0xC01A] = 'TLS_SRP_SHA_WITH_3DES_EDE_CBC_SHA'
     TLS_SRP_SHA_WITH_AES_128_CBC_SHA = 0xC01D
+    ietfNames[0xC01D] = 'TLS_SRP_SHA_WITH_AES_128_CBC_SHA'
     TLS_SRP_SHA_WITH_AES_256_CBC_SHA = 0xC020
+    ietfNames[0xC020] = 'TLS_SRP_SHA_WITH_AES_256_CBC_SHA'
 
+    # RFC 5054 - Secure Remote Password (SRP) Protocol for TLS Authentication
     TLS_SRP_SHA_RSA_WITH_3DES_EDE_CBC_SHA = 0xC01B
+    ietfNames[0xC01B] = 'TLS_SRP_SHA_RSA_WITH_3DES_EDE_CBC_SHA'
     TLS_SRP_SHA_RSA_WITH_AES_128_CBC_SHA = 0xC01E
+    ietfNames[0xC01E] = 'TLS_SRP_SHA_RSA_WITH_AES_128_CBC_SHA'
     TLS_SRP_SHA_RSA_WITH_AES_256_CBC_SHA = 0xC021
+    ietfNames[0xC021] = 'TLS_SRP_SHA_RSA_WITH_AES_256_CBC_SHA'
 
 
+    # RFC 5246 - TLS v1.2 Protocol
     TLS_RSA_WITH_3DES_EDE_CBC_SHA = 0x000A
+    ietfNames[0x000A] = 'TLS_RSA_WITH_3DES_EDE_CBC_SHA'
     TLS_RSA_WITH_AES_128_CBC_SHA = 0x002F
+    ietfNames[0x002F] = 'TLS_RSA_WITH_AES_128_CBC_SHA'
     TLS_RSA_WITH_AES_256_CBC_SHA = 0x0035
+    ietfNames[0x0035] = 'TLS_RSA_WITH_AES_256_CBC_SHA'
     TLS_RSA_WITH_RC4_128_SHA = 0x0005
+    ietfNames[0x0005] = 'TLS_RSA_WITH_RC4_128_SHA'
     
+    # RFC 5246 - TLS v1.2 Protocol
     TLS_RSA_WITH_RC4_128_MD5 = 0x0004
+    ietfNames[0x0004] = 'TLS_RSA_WITH_RC4_128_MD5'
 
+    # RFC 5246 - TLS v1.2 Protocol
     TLS_DH_ANON_WITH_AES_128_CBC_SHA = 0x0034
+    ietfNames[0x0034] = 'TLS_DH_ANON_WITH_AES_128_CBC_SHA'
     TLS_DH_ANON_WITH_AES_256_CBC_SHA = 0x003A
+    ietfNames[0x003A] = 'TLS_DH_ANON_WITH_AES_256_CBC_SHA'
 
+    # RFC 5246 - TLS v1.2 Protocol
     TLS_RSA_WITH_AES_128_CBC_SHA256 = 0x003C
+    ietfNames[0x003C] = 'TLS_RSA_WITH_AES_128_CBC_SHA256'
     TLS_RSA_WITH_AES_256_CBC_SHA256 = 0x003D
+    ietfNames[0x003D] = 'TLS_RSA_WITH_AES_256_CBC_SHA256'
 
+    #
+    # Define cipher suite families below
+    #
+
+    # 3DES CBC ciphers
     tripleDESSuites = []
     tripleDESSuites.append(TLS_SRP_SHA_WITH_3DES_EDE_CBC_SHA)
     tripleDESSuites.append(TLS_SRP_SHA_RSA_WITH_3DES_EDE_CBC_SHA)
     tripleDESSuites.append(TLS_RSA_WITH_3DES_EDE_CBC_SHA)
 
+    # AES-128 CBC ciphers
     aes128Suites = []
     aes128Suites.append(TLS_SRP_SHA_WITH_AES_128_CBC_SHA)
     aes128Suites.append(TLS_SRP_SHA_RSA_WITH_AES_128_CBC_SHA)
@@ -155,6 +219,7 @@ class CipherSuite:
     aes128Suites.append(TLS_DH_ANON_WITH_AES_128_CBC_SHA)
     aes128Suites.append(TLS_RSA_WITH_AES_128_CBC_SHA256)
 
+    # AES-256 CBC ciphers
     aes256Suites = []
     aes256Suites.append(TLS_SRP_SHA_WITH_AES_256_CBC_SHA)
     aes256Suites.append(TLS_SRP_SHA_RSA_WITH_AES_256_CBC_SHA)
@@ -162,10 +227,12 @@ class CipherSuite:
     aes256Suites.append(TLS_DH_ANON_WITH_AES_256_CBC_SHA)
     aes256Suites.append(TLS_RSA_WITH_AES_256_CBC_SHA256)
 
+    # RC4-128 stream cipher
     rc4Suites = []
     rc4Suites.append(TLS_RSA_WITH_RC4_128_SHA)
     rc4Suites.append(TLS_RSA_WITH_RC4_128_MD5)
     
+    # SHA-1 HMAC, protocol default PRF
     shaSuites = []
     shaSuites.append(TLS_SRP_SHA_WITH_3DES_EDE_CBC_SHA)
     shaSuites.append(TLS_SRP_SHA_WITH_AES_128_CBC_SHA)
@@ -180,10 +247,12 @@ class CipherSuite:
     shaSuites.append(TLS_DH_ANON_WITH_AES_128_CBC_SHA)
     shaSuites.append(TLS_DH_ANON_WITH_AES_256_CBC_SHA)
     
+    # SHA-256 HMAC, SHA-256 PRF
     sha256Suites = []
     sha256Suites.append(TLS_RSA_WITH_AES_128_CBC_SHA256)
     sha256Suites.append(TLS_RSA_WITH_AES_256_CBC_SHA256)
 
+    # MD-5 HMAC, protocol default PRF
     md5Suites = []
     md5Suites.append(TLS_RSA_WITH_RC4_128_MD5)
 
@@ -211,6 +280,7 @@ class CipherSuite:
 
         return [s for s in suites if s in macSuites and s in cipherSuites]
 
+    # SRP key exchange
     srpSuites = []
     srpSuites.append(TLS_SRP_SHA_WITH_AES_256_CBC_SHA)
     srpSuites.append(TLS_SRP_SHA_WITH_AES_128_CBC_SHA)
@@ -220,6 +290,7 @@ class CipherSuite:
     def getSrpSuites(settings):
         return CipherSuite._filterSuites(CipherSuite.srpSuites, settings)
 
+    # SRP key exchange, RSA authentication
     srpCertSuites = []
     srpCertSuites.append(TLS_SRP_SHA_RSA_WITH_AES_256_CBC_SHA)
     srpCertSuites.append(TLS_SRP_SHA_RSA_WITH_AES_128_CBC_SHA)
@@ -235,6 +306,7 @@ class CipherSuite:
     def getSrpAllSuites(settings):
         return CipherSuite._filterSuites(CipherSuite.srpAllSuites, settings)
 
+    # RSA key exchange, RSA authentication
     certSuites = []
     certSuites.append(TLS_RSA_WITH_AES_256_CBC_SHA256)
     certSuites.append(TLS_RSA_WITH_AES_128_CBC_SHA256)
@@ -243,12 +315,14 @@ class CipherSuite:
     certSuites.append(TLS_RSA_WITH_3DES_EDE_CBC_SHA)
     certSuites.append(TLS_RSA_WITH_RC4_128_SHA)
     certSuites.append(TLS_RSA_WITH_RC4_128_MD5)
+    # RSA authentication
     certAllSuites = srpCertSuites + certSuites
     
     @staticmethod
     def getCertSuites(settings):
         return CipherSuite._filterSuites(CipherSuite.certSuites, settings)
 
+    # anon FFDHE key exchange
     anonSuites = []
     anonSuites.append(TLS_DH_ANON_WITH_AES_256_CBC_SHA)
     anonSuites.append(TLS_DH_ANON_WITH_AES_128_CBC_SHA)

--- a/tlslite/constants.py
+++ b/tlslite/constants.py
@@ -157,7 +157,7 @@ class CipherSuite:
     # Downgrade Attacks
     TLS_FALLBACK_SCSV = 0x5600
     ietfNames[0x5600] = 'TLS_FALLBACK_SCSV'
-    
+
     # RFC 5054 - Secure Remote Password (SRP) Protocol for TLS Authentication
     TLS_SRP_SHA_WITH_3DES_EDE_CBC_SHA  = 0xC01A
     ietfNames[0xC01A] = 'TLS_SRP_SHA_WITH_3DES_EDE_CBC_SHA'
@@ -184,7 +184,7 @@ class CipherSuite:
     ietfNames[0x0035] = 'TLS_RSA_WITH_AES_256_CBC_SHA'
     TLS_RSA_WITH_RC4_128_SHA = 0x0005
     ietfNames[0x0005] = 'TLS_RSA_WITH_RC4_128_SHA'
-    
+
     # RFC 5246 - TLS v1.2 Protocol
     TLS_RSA_WITH_RC4_128_MD5 = 0x0004
     ietfNames[0x0004] = 'TLS_RSA_WITH_RC4_128_MD5'
@@ -231,7 +231,7 @@ class CipherSuite:
     rc4Suites = []
     rc4Suites.append(TLS_RSA_WITH_RC4_128_SHA)
     rc4Suites.append(TLS_RSA_WITH_RC4_128_MD5)
-    
+
     # SHA-1 HMAC, protocol default PRF
     shaSuites = []
     shaSuites.append(TLS_SRP_SHA_WITH_3DES_EDE_CBC_SHA)
@@ -246,7 +246,7 @@ class CipherSuite:
     shaSuites.append(TLS_RSA_WITH_RC4_128_SHA)
     shaSuites.append(TLS_DH_ANON_WITH_AES_128_CBC_SHA)
     shaSuites.append(TLS_DH_ANON_WITH_AES_256_CBC_SHA)
-    
+
     # SHA-256 HMAC, SHA-256 PRF
     sha256Suites = []
     sha256Suites.append(TLS_RSA_WITH_AES_128_CBC_SHA256)
@@ -285,7 +285,7 @@ class CipherSuite:
     srpSuites.append(TLS_SRP_SHA_WITH_AES_256_CBC_SHA)
     srpSuites.append(TLS_SRP_SHA_WITH_AES_128_CBC_SHA)
     srpSuites.append(TLS_SRP_SHA_WITH_3DES_EDE_CBC_SHA)
-    
+
     @staticmethod
     def getSrpSuites(settings):
         return CipherSuite._filterSuites(CipherSuite.srpSuites, settings)
@@ -295,7 +295,7 @@ class CipherSuite:
     srpCertSuites.append(TLS_SRP_SHA_RSA_WITH_AES_256_CBC_SHA)
     srpCertSuites.append(TLS_SRP_SHA_RSA_WITH_AES_128_CBC_SHA)
     srpCertSuites.append(TLS_SRP_SHA_RSA_WITH_3DES_EDE_CBC_SHA)
-    
+
     @staticmethod
     def getSrpCertSuites(settings):
         return CipherSuite._filterSuites(CipherSuite.srpCertSuites, settings)
@@ -317,7 +317,7 @@ class CipherSuite:
     certSuites.append(TLS_RSA_WITH_RC4_128_MD5)
     # RSA authentication
     certAllSuites = srpCertSuites + certSuites
-    
+
     @staticmethod
     def getCertSuites(settings):
         return CipherSuite._filterSuites(CipherSuite.certSuites, settings)
@@ -326,7 +326,7 @@ class CipherSuite:
     anonSuites = []
     anonSuites.append(TLS_DH_ANON_WITH_AES_256_CBC_SHA)
     anonSuites.append(TLS_DH_ANON_WITH_AES_128_CBC_SHA)
-    
+
     @staticmethod
     def getAnonSuites(settings):
         return CipherSuite._filterSuites(CipherSuite.anonSuites, settings)

--- a/tlslite/messages.py
+++ b/tlslite/messages.py
@@ -1037,6 +1037,7 @@ class ClientKeyExchange(HandshakeMsg):
         self.cipherSuite = cipherSuite
         self.version = version
         self.srp_A = 0
+        self.dh_Yc = 0
         self.encryptedPreMasterSecret = bytearray(0)
 
     def createSRP(self, srp_A):

--- a/tlslite/messages.py
+++ b/tlslite/messages.py
@@ -922,7 +922,37 @@ class CertificateRequest(HandshakeMsg):
         return self.postWrite(w)
 
 class ServerKeyExchange(HandshakeMsg):
+
+    """
+    Handling TLS Handshake protocol Server Key Exchange messages
+
+    @type cipherSuite: int
+    @cvar cipherSuite: id of ciphersuite selected in Server Hello message
+    @type srp_N: int
+    @cvar srp_N: SRP protocol prime
+    @type srp_g: int
+    @cvar srp_g: SRP protocol generator
+    @type srp_s: bytearray
+    @cvar srp_s: SRP protocol salt value
+    @type srp_B: int
+    @cvar srp_B: SRP protocol server public value
+    @type dh_p: int
+    @cvar dh_p: FFDHE protocol prime
+    @type dh_g: int
+    @cvar dh_g: FFDHE protocol generator
+    @type dh_Ys: int
+    @cvar dh_Ys: FFDH protocol server key share
+    @type signature: bytearray
+    @cvar signature: signature performed over the parameters by server
+    """
+
     def __init__(self, cipherSuite):
+        """
+        Initialise Server Key Exchange for reading or writing
+
+        @type cipherSuite: int
+        @param cipherSuite: id of ciphersuite selected by server
+        """
         HandshakeMsg.__init__(self, HandshakeType.server_key_exchange)
         self.cipherSuite = cipherSuite
         self.srp_N = 0
@@ -936,19 +966,26 @@ class ServerKeyExchange(HandshakeMsg):
         self.signature = bytearray(0)
 
     def createSRP(self, srp_N, srp_g, srp_s, srp_B):
+        """Set SRP protocol parameters"""
         self.srp_N = srp_N
         self.srp_g = srp_g
         self.srp_s = srp_s
         self.srp_B = srp_B
         return self
-    
+
     def createDH(self, dh_p, dh_g, dh_Ys):
+        """Set FFDH protocol parameters"""
         self.dh_p = dh_p
         self.dh_g = dh_g
         self.dh_Ys = dh_Ys
         return self
 
     def parse(self, p):
+        """Deserialise message from L{Parser}
+
+        @type p: L{Parser}
+        @param p: parser to read data from
+        """
         p.startLengthCheck(3)
         if self.cipherSuite in CipherSuite.srpAllSuites:
             self.srp_N = bytesToNumber(p.getVarBytes(2))
@@ -965,6 +1002,10 @@ class ServerKeyExchange(HandshakeMsg):
         return self
 
     def write(self):
+        """Serialise message
+
+        @rtype: bytearray
+        """
         w = Writer()
         if self.cipherSuite in CipherSuite.srpAllSuites:
             w.addVarSeq(numberToByteArray(self.srp_N), 1, 2)
@@ -982,6 +1023,7 @@ class ServerKeyExchange(HandshakeMsg):
         return self.postWrite(w)
 
     def hash(self, clientRandom, serverRandom):
+        """Calculate the signature hash"""
         oldCipherSuite = self.cipherSuite
         self.cipherSuite = None
         try:

--- a/tlslite/messages.py
+++ b/tlslite/messages.py
@@ -1077,31 +1077,31 @@ class ClientKeyExchange(HandshakeMsg):
         self.dh_Yc = dh_Yc
         return self
     
-    def parse(self, p):
+    def parse(self, parser):
         """
         Deserialise the message from L{Parser}
 
         returns self
 
-        @type p: L{Parser}
+        @type parser: L{Parser}
         @rtype: L{ClientKeyExchange}
         """
-        p.startLengthCheck(3)
+        parser.startLengthCheck(3)
         if self.cipherSuite in CipherSuite.srpAllSuites:
-            self.srp_A = bytesToNumber(p.getVarBytes(2))
+            self.srp_A = bytesToNumber(parser.getVarBytes(2))
         elif self.cipherSuite in CipherSuite.certSuites:
             if self.version in ((3,1), (3,2), (3,3)):
-                self.encryptedPreMasterSecret = p.getVarBytes(2)
+                self.encryptedPreMasterSecret = parser.getVarBytes(2)
             elif self.version == (3,0):
                 self.encryptedPreMasterSecret = \
-                    p.getFixBytes(len(p.bytes)-p.index)
+                    parser.getFixBytes(parser.getRemainingLength())
             else:
                 raise AssertionError()
         elif self.cipherSuite in CipherSuite.anonSuites:
-            self.dh_Yc = bytesToNumber(p.getVarBytes(2))            
+            self.dh_Yc = bytesToNumber(parser.getVarBytes(2))
         else:
             raise AssertionError()
-        p.stopLengthCheck()
+        parser.stopLengthCheck()
         return self
 
     def write(self):

--- a/tlslite/messages.py
+++ b/tlslite/messages.py
@@ -980,25 +980,25 @@ class ServerKeyExchange(HandshakeMsg):
         self.dh_Ys = dh_Ys
         return self
 
-    def parse(self, p):
+    def parse(self, parser):
         """Deserialise message from L{Parser}
 
-        @type p: L{Parser}
-        @param p: parser to read data from
+        @type parser: L{Parser}
+        @param parser: parser to read data from
         """
-        p.startLengthCheck(3)
+        parser.startLengthCheck(3)
         if self.cipherSuite in CipherSuite.srpAllSuites:
-            self.srp_N = bytesToNumber(p.getVarBytes(2))
-            self.srp_g = bytesToNumber(p.getVarBytes(2))
-            self.srp_s = p.getVarBytes(1)
-            self.srp_B = bytesToNumber(p.getVarBytes(2))
+            self.srp_N = bytesToNumber(parser.getVarBytes(2))
+            self.srp_g = bytesToNumber(parser.getVarBytes(2))
+            self.srp_s = parser.getVarBytes(1)
+            self.srp_B = bytesToNumber(parser.getVarBytes(2))
             if self.cipherSuite in CipherSuite.srpCertSuites:
-                self.signature = p.getVarBytes(2)
+                self.signature = parser.getVarBytes(2)
         elif self.cipherSuite in CipherSuite.anonSuites:
-            self.dh_p = bytesToNumber(p.getVarBytes(2))
-            self.dh_g = bytesToNumber(p.getVarBytes(2))
-            self.dh_Ys = bytesToNumber(p.getVarBytes(2))
-        p.stopLengthCheck()
+            self.dh_p = bytesToNumber(parser.getVarBytes(2))
+            self.dh_g = bytesToNumber(parser.getVarBytes(2))
+            self.dh_Ys = bytesToNumber(parser.getVarBytes(2))
+        parser.stopLengthCheck()
         return self
 
     def write(self):
@@ -1006,21 +1006,21 @@ class ServerKeyExchange(HandshakeMsg):
 
         @rtype: bytearray
         """
-        w = Writer()
+        writer = Writer()
         if self.cipherSuite in CipherSuite.srpAllSuites:
-            w.addVarSeq(numberToByteArray(self.srp_N), 1, 2)
-            w.addVarSeq(numberToByteArray(self.srp_g), 1, 2)
-            w.addVarSeq(self.srp_s, 1, 1)
-            w.addVarSeq(numberToByteArray(self.srp_B), 1, 2)
+            writer.addVarSeq(numberToByteArray(self.srp_N), 1, 2)
+            writer.addVarSeq(numberToByteArray(self.srp_g), 1, 2)
+            writer.addVarSeq(self.srp_s, 1, 1)
+            writer.addVarSeq(numberToByteArray(self.srp_B), 1, 2)
             if self.cipherSuite in CipherSuite.srpCertSuites:
-                w.addVarSeq(self.signature, 1, 2)
+                writer.addVarSeq(self.signature, 1, 2)
         elif self.cipherSuite in CipherSuite.anonSuites:
-            w.addVarSeq(numberToByteArray(self.dh_p), 1, 2)
-            w.addVarSeq(numberToByteArray(self.dh_g), 1, 2)
-            w.addVarSeq(numberToByteArray(self.dh_Ys), 1, 2)
+            writer.addVarSeq(numberToByteArray(self.dh_p), 1, 2)
+            writer.addVarSeq(numberToByteArray(self.dh_g), 1, 2)
+            writer.addVarSeq(numberToByteArray(self.dh_Ys), 1, 2)
             if self.cipherSuite in []: # TODO support for signed_params
-                w.addVarSeq(self.signature, 1, 2)
-        return self.postWrite(w)
+                writer.addVarSeq(self.signature, 1, 2)
+        return self.postWrite(writer)
 
     def hash(self, clientRandom, serverRandom):
         """Calculate the signature hash"""

--- a/tlslite/messages.py
+++ b/tlslite/messages.py
@@ -1007,7 +1007,32 @@ class ServerHelloDone(HandshakeMsg):
         return self.postWrite(w)
 
 class ClientKeyExchange(HandshakeMsg):
+
+    """
+    Handling of TLS Handshake protocol ClientKeyExchange message
+
+    @type cipherSuite: int
+    @ivar cipherSuite: the cipher suite id used for the connection
+    @type version: tuple(int, int)
+    @ivar version: TLS protocol version used for the connection
+    @type srp_A: int
+    @ivar srp_A: SRP protocol client answer value
+    @type dh_Yc: int
+    @ivar dh_Yc: client Finite Field Diffie-Hellman protocol key share
+    @type encryptedPreMasterSecret: bytearray
+    @ivar encryptedPreMasterSecret: client selected PremMaster secret encrypted
+    with server public key (from certificate)
+    """
+
     def __init__(self, cipherSuite, version=None):
+        """
+        Initialise ClientKeyExchange for reading or writing
+
+        @type cipherSuite: int
+        @param cipherSuite: id of the ciphersuite selected by server
+        @type version: tuple(int, int)
+        @param version: protocol version selected by server
+        """
         HandshakeMsg.__init__(self, HandshakeType.client_key_exchange)
         self.cipherSuite = cipherSuite
         self.version = version
@@ -1015,18 +1040,51 @@ class ClientKeyExchange(HandshakeMsg):
         self.encryptedPreMasterSecret = bytearray(0)
 
     def createSRP(self, srp_A):
+        """
+        Set the SRP client answer
+
+        returns self
+
+        @type srp_A: int
+        @param srp_A: client SRP answer
+        @rtype: L{ClientKeyExchange}
+        """
         self.srp_A = srp_A
         return self
 
     def createRSA(self, encryptedPreMasterSecret):
+        """
+        Set the encrypted PreMaster Secret
+
+        returns self
+
+        @type encryptedPreMasterSecret: bytearray
+        @rtype: L{ClientKeyExchange}
+        """
         self.encryptedPreMasterSecret = encryptedPreMasterSecret
         return self
     
     def createDH(self, dh_Yc):
+        """
+        Set the client FFDH key share
+
+        returns self
+
+        @type dh_Yc: int
+        @rtype: L{ClientKeyExchange}
+        """
         self.dh_Yc = dh_Yc
         return self
     
     def parse(self, p):
+        """
+        Deserialise the message from L{Parser}
+
+        returns self
+
+        @type p: L{Parser}
+        @rtype: L{ClientKeyExchange}
+        """
         p.startLengthCheck(3)
         if self.cipherSuite in CipherSuite.srpAllSuites:
             self.srp_A = bytesToNumber(p.getVarBytes(2))
@@ -1046,6 +1104,11 @@ class ClientKeyExchange(HandshakeMsg):
         return self
 
     def write(self):
+        """
+        Serialise the object
+
+        @rtype: bytearray
+        """
         w = Writer()
         if self.cipherSuite in CipherSuite.srpAllSuites:
             w.addVarSeq(numberToByteArray(self.srp_A), 1, 2)

--- a/tlslite/recordlayer.py
+++ b/tlslite/recordlayer.py
@@ -368,8 +368,6 @@ class RecordLayer(object):
 
         @param msg: TLS message to send
         @type msg: ApplicationData, HandshakeMessage, etc.
-        @param randomizeFirstBlock: set to perform 1/n-1 record splitting in
-        SSLv3 and TLSv1.0 in application data
         """
         data = msg.write()
         contentType = msg.contentType

--- a/unit_tests/test_tlslite_messages.py
+++ b/unit_tests/test_tlslite_messages.py
@@ -1419,6 +1419,11 @@ class TestServerKeyExchange(unittest.TestCase):
 
         hash1 = ske.hash(bytearray(32), bytearray(32))
 
+        self.assertEqual(hash1, bytearray(
+            b'\xcb\xe6\xd3=\x8b$\xff\x97e&\xb2\x89\x1dA\xab>' +
+            b'\x8e?YW\xcd\xad\xc6\x83\x91\x1d.fe,\x17y' +
+            b'=\xc4T\x89'))
+
         ske2 = ServerKeyExchange(0)
         hash2 = ske2.hash(bytearray(32), bytearray(32))
         self.assertEqual(len(hash2), 36)
@@ -1427,8 +1432,7 @@ class TestServerKeyExchange(unittest.TestCase):
             b'\xc8\xd7\xd0\xef\x0e\xed\xfa\x82\xd2\xea\x1a\xa5\x92\x84[\x9a' +
             b'mK\x02\xb7'))
 
-        # XXX seriously?!
-        self.assertEqual(hash1, hash2)
+        self.assertNotEqual(hash1, hash2)
 
 if __name__ == '__main__':
     unittest.main()


### PR DESCRIPTION
Clean up code in CipherSuite, ClientKeyExchange and ServerKeyExchange

 - add documentation for the above classes
 - fix incorrect signing and signature verification of SRP_SHA_RSA ciphersuites in TLS < v1.2.