### PR TITLE
Little cleanup

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -23,7 +23,7 @@ clean:
 	rm -rf tlslite/utils/__pycache__
 	rm -rf tlslite/*.pyc
 	rm -rf tlslite/utils/*.pyc
-	rm -rf tlslite/integration/*.pyc	
+	rm -rf tlslite/integration/*.pyc
 	rm -rf unit_tests/*.pyc
 	rm -rf unit_tests/__pycache__
 	rm -rf dist

--- a/scripts/tls.py
+++ b/scripts/tls.py
@@ -28,6 +28,7 @@ if __name__ != "__main__":
     raise "This must be run as a command, not used as a module!"
 
 from tlslite.api import *
+from tlslite.constants import CipherSuite
 from tlslite import __version__
 
 try:
@@ -164,6 +165,8 @@ def printGoodConnection(connection, seconds):
     print("  Version: %s" % connection.getVersionName())
     print("  Cipher: %s %s" % (connection.getCipherName(), 
         connection.getCipherImplementation()))
+    print("  Ciphersuite: {0}".\
+            format(CipherSuite.ietfNames[connection.session.cipherSuite]))
     if connection.session.srpUsername:
         print("  Client SRP username: %s" % connection.session.srpUsername)
     if connection.session.clientCertChain:

--- a/scripts/tls.py
+++ b/scripts/tls.py
@@ -172,6 +172,8 @@ def printGoodConnection(connection, seconds):
     if connection.session.clientCertChain:
         print("  Client X.509 SHA1 fingerprint: %s" % 
             connection.session.clientCertChain.getFingerprint())
+    else:
+        print("  No client certificate provided by peer")
     if connection.session.serverCertChain:
         print("  Server X.509 SHA1 fingerprint: %s" % 
             connection.session.serverCertChain.getFingerprint())
@@ -266,6 +268,8 @@ def serverCmd(argv):
         print("Using verifier DB...")
     if tacks:
         print("Using Tacks...")
+    if reqCert:
+        print("Asking for client certificates...")
         
     #############
     sessionCache = SessionCache()
@@ -291,7 +295,8 @@ def serverCmd(argv):
                                               activationFlags=activationFlags,
                                               sessionCache=sessionCache,
                                               settings=settings,
-                                              nextProtos=[b"http/1.1"])
+                                              nextProtos=[b"http/1.1"],
+                                              reqCert=reqCert)
                                               # As an example (does not work here):
                                               #nextProtos=[b"spdy/3", b"spdy/2", b"http/1.1"])
                 stop = time.clock()

--- a/tlslite/handshakehashes.py
+++ b/tlslite/handshakehashes.py
@@ -1,0 +1,99 @@
+# Copyright (c) 2015, Hubert Kario
+#
+# See the LICENSE file for legal information regarding use of this file.
+"""Handling cryptographic hashes for handshake protocol"""
+
+from .utils.compat import compat26Str, compatHMAC
+from .utils.cryptomath import MD5, SHA1
+import hashlib
+
+class HandshakeHashes(object):
+
+    """
+    Store and calculate necessary hashes for handshake protocol
+
+    Calculates message digests of messages exchanged in handshake protocol
+    of SSLv3 and TLS.
+    """
+
+    def __init__(self):
+        """Create instance"""
+        self._handshakeMD5 = hashlib.md5()
+        self._handshakeSHA = hashlib.sha1()
+        self._handshakeSHA256 = hashlib.sha256()
+
+    def update(self, data):
+        """
+        Add L{data} to hash input.
+
+        @type data: bytearray
+        @param data: serialized TLS handshake message
+        """
+        text = compat26Str(data)
+        self._handshakeMD5.update(text)
+        self._handshakeSHA.update(text)
+        self._handshakeSHA256.update(text)
+
+    def digest(self, digest=None):
+        """
+        Calculate and return digest for the already consumed data.
+
+        Used for Finished and CertificateVerify messages.
+
+        @type digest: str
+        @param digest: name of digest to return
+        """
+        if digest is None:
+            return self._handshakeMD5.digest() + self._handshakeSHA.digest()
+        elif digest == 'md5':
+            return self._handshakeMD5.digest()
+        elif digest == 'sha1':
+            return self._handshakeSHA.digest()
+        elif digest == 'sha256':
+            return self._handshakeSHA256.digest()
+        else:
+            raise ValueError("Unknown digest name")
+
+    def digestSSL(self, masterSecret, label):
+        """
+        Calculate and return digest for already consumed data (SSLv3 version)
+
+        Used for Finished and CertificateVerify messages.
+
+        @type masterSecret: bytearray
+        @param masterSecret: value of the master secret
+        @type label: bytearray
+        @param label: label to include in the calculation
+        """
+        #pylint: disable=maybe-no-member
+        imacMD5 = self._handshakeMD5.copy()
+        imacSHA = self._handshakeSHA.copy()
+        #pylint: enable=maybe-no-member
+
+        # the below difference in input for MD5 and SHA-1 is why we can't reuse
+        # digest() method
+        imacMD5.update(compatHMAC(label + masterSecret + bytearray([0x36]*48)))
+        imacSHA.update(compatHMAC(label + masterSecret + bytearray([0x36]*40)))
+
+        md5Bytes = MD5(masterSecret + bytearray([0x5c]*48) + \
+                         bytearray(imacMD5.digest()))
+        shaBytes = SHA1(masterSecret + bytearray([0x5c]*40) + \
+                         bytearray(imacSHA.digest()))
+
+        return md5Bytes + shaBytes
+
+    #pylint: disable=protected-access, maybe-no-member
+    def copy(self):
+        """
+        Copy object
+
+        Return a copy of the object with all the hashes in the same state
+        as the source object.
+
+        @rtype: HandshakeHashes
+        """
+        other = HandshakeHashes()
+        other._handshakeMD5 = self._handshakeMD5.copy()
+        other._handshakeSHA = self._handshakeSHA.copy()
+        other._handshakeSHA256 = self._handshakeSHA256.copy()
+        return other

--- a/tlslite/messages.py
+++ b/tlslite/messages.py
@@ -769,8 +769,9 @@ class ServerHello(HandshakeMsg):
         self.next_protos = val
 
     def create(self, version, random, session_id, cipher_suite,
-               certificate_type, tackExt, next_protos_advertised,
+               certificate_type=None, tackExt=None, next_protos_advertised=None,
                extensions=None):
+        """Initialize the object for deserialisation"""
         self.extensions = extensions
         self.server_version = version
         self.random = random
@@ -778,7 +779,8 @@ class ServerHello(HandshakeMsg):
         self.cipher_suite = cipher_suite
         self.certificate_type = certificate_type
         self.compression_method = 0
-        self.tackExt = tackExt
+        if tackExt is not None:
+            self.tackExt = tackExt
         self.next_protos_advertised = next_protos_advertised
         return self
 

--- a/tlslite/messagesocket.py
+++ b/tlslite/messagesocket.py
@@ -1,0 +1,185 @@
+# vim: set fileencoding=utf8
+#
+# Copyright © 2015, Hubert Kario
+#
+# See the LICENSE file for legal information regarding use of this file.
+
+"""Wrapper of TLS RecordLayer providing message-level abstraction"""
+
+from .recordlayer import RecordLayer
+from .constants import ContentType
+from .messages import RecordHeader3, Message
+from .utils.codec import Parser
+
+class MessageSocket(RecordLayer):
+
+    """TLS Record Layer socket that provides Message level abstraction
+
+    Because the record layer has a hard size limit on sent messages, they need
+    to be fragmented before sending. Similarly, a single record layer record
+    can include multiple handshake protocol messages (very common with
+    ServerHello, Certificate and ServerHelloDone), as such, the user of
+    RecordLayer needs to fragment those records into multiple messages.
+    Unfortunately, fragmentation of messages requires some degree of
+    knowledge about the messages passed and as such is outside scope of pure
+    record layer implementation.
+
+    This class tries to provide a useful abstraction for handling Handshake
+    protocol messages.
+
+    @type recordSize: int
+    @ivar recordSize: maximum size of records sent through socket. Messages
+    bigger than this size will be fragmented to smaller chunks. Setting it
+    to higher value than the default 2^14 will make the implementation
+    non RFC compliant and likely not interoperable with other peers.
+
+    @type defragmenter: L{Defragmenter}
+    @ivar defragmenter: defragmenter used for read records
+
+    @type unfragmentedDataTypes: tuple
+    @ivar unfragmentedDataTypes: data types which will be passed as-read,
+    TLS application_data by default
+    """
+
+    def __init__(self, sock, defragmenter):
+        """Apply TLS Record Layer abstraction to raw network socket.
+
+        @type sock: L{socket.socket}
+        @param sock: network socket to wrap
+        @type defragmenter: L{Defragmenter}
+        @param defragmenter: defragmenter to apply on the records read
+        """
+        super(MessageSocket, self).__init__(sock)
+
+        self.defragmenter = defragmenter
+        self.unfragmentedDataTypes = tuple((ContentType.application_data, ))
+        self._lastRecordVersion = (0, 0)
+
+        self._sendBuffer = bytearray(0)
+        self._sendBufferType = None
+
+        self.recordSize = 2**14
+
+    def recvMessage(self):
+        """
+        Read next message in queue
+
+        will return a 0 or 1 if the read is blocking, a tuple of
+        L{RecordHeader3} and L{Parser} in case a message was received.
+
+        @rtype: generator
+        """
+        while True:
+            while True:
+                ret = self.defragmenter.getMessage()
+                if ret is None:
+                    break
+                header = RecordHeader3().create(self._lastRecordVersion,
+                                                ret[0],
+                                                0)
+                yield header, Parser(ret[1])
+
+            for ret in self.recvRecord():
+                if ret in (0, 1):
+                    yield ret
+                else:
+                    break
+
+            header, parser = ret
+            if header.type in self.unfragmentedDataTypes:
+                yield ret
+            # TODO probably needs a bit better handling...
+            if header.ssl2:
+                yield ret
+
+            self.defragmenter.addData(header.type, parser.bytes)
+            self._lastRecordVersion = header.version
+
+    def recvMessageBlocking(self):
+        """Blocking variant of L{recvMessage}"""
+        for res in self.recvMessage():
+            if res in (0, 1):
+                pass
+            else:
+                return res
+
+    def flush(self):
+        """
+        Empty the queue of messages to write
+
+        Will fragment the messages and write them in as little records as
+        possible.
+
+        @rtype: generator
+        """
+        while len(self._sendBuffer) > 0:
+            recordPayload = self._sendBuffer[:self.recordSize]
+            self._sendBuffer = self._sendBuffer[self.recordSize:]
+            msg = Message(self._sendBufferType, recordPayload)
+            for res in self.sendRecord(msg):
+                yield res
+
+        assert len(self._sendBuffer) == 0
+        self._sendBufferType = None
+
+    def flushBlocking(self):
+        """Blocking variant of L{flush}"""
+        for _ in self.flush():
+            pass
+
+    def queueMessage(self, msg):
+        """
+        Queue message for sending
+
+        If the message is of same type as messages in queue, the message is
+        just added to queue.
+
+        If the message is of different type as messages in queue, the queue is
+        flushed and then the message is queued.
+
+        @rtype: generator
+        """
+        if self._sendBufferType is None:
+            self._sendBufferType = msg.contentType
+
+        if msg.contentType == self._sendBufferType:
+            self._sendBuffer += msg.write()
+            return
+
+        for res in self.flush():
+            yield res
+
+        assert self._sendBufferType is None
+        self._sendBufferType = msg.contentType
+        self._sendBuffer += msg.write()
+
+    def queueMessageBlocking(self, msg):
+        """Blocking variant of L{queueMessage}"""
+        for _ in self.queueMessage(msg):
+            pass
+
+    def sendMessage(self, msg):
+        """
+        Fragment and send a message.
+
+        If a messages already of same type reside in queue, the message if
+        first added to it and then the queue is flushed.
+
+        If the message is of different type than the queue, the queue is
+        flushed, the message is added to queue and the queue is flushed again.
+
+        Use the sendRecord() message if you want to send a message outside
+        the queue, or a message of zero size.
+
+        @rtype: generator
+        """
+        for res in self.queueMessage(msg):
+            yield res
+
+        for res in self.flush():
+            yield res
+
+    def sendMessageBlocking(self, msg):
+        """Blocking variant of L{sendMessage}"""
+        for _ in self.sendMessage(msg):
+            pass

--- a/tlslite/recordlayer.py
+++ b/tlslite/recordlayer.py
@@ -564,9 +564,9 @@ class RecordLayer(object):
             raise TLSBadRecordMAC("Invalid tag, decryption failure")
         return buf
 
-    def recvMessage(self):
+    def recvRecord(self):
         """
-        Read, decrypt and check integrity of message
+        Read, decrypt and check integrity of a single record
 
         @rtype: tuple
         @return: message header and decrypted message payload

--- a/tlslite/recordlayer.py
+++ b/tlslite/recordlayer.py
@@ -385,9 +385,12 @@ class RecordLayer(object):
 
         return buf
 
-    def sendMessage(self, msg):
+    def sendRecord(self, msg):
         """
-        Encrypt, MAC and send message through socket.
+        Encrypt, MAC and send arbitrary message as-is through socket.
+
+        Note that if the message was not fragmented to below 2**14 bytes
+        it will be rejected by the other connection side.
 
         @param msg: TLS message to send
         @type msg: ApplicationData, HandshakeMessage, etc.

--- a/tlslite/tlsrecordlayer.py
+++ b/tlslite/tlsrecordlayer.py
@@ -828,7 +828,7 @@ class TLSRecordLayer(object):
 
         try:
             # otherwise... read the next record
-            for result in self._recordLayer.recvMessage():
+            for result in self._recordLayer.recvRecord():
                 if result in (0, 1):
                     yield result
                 else:

--- a/tlslite/tlsrecordlayer.py
+++ b/tlslite/tlsrecordlayer.py
@@ -582,7 +582,7 @@ class TLSRecordLayer(object):
         """Send message, handle errors"""
 
         try:
-            for result in self._recordLayer.sendMessage(msg):
+            for result in self._recordLayer.sendRecord(msg):
                 if result in (0, 1):
                     yield result
         except socket.error:

--- a/tlslite/tlsrecordlayer.py
+++ b/tlslite/tlsrecordlayer.py
@@ -20,6 +20,7 @@ from .mathtls import *
 from .constants import *
 from .recordlayer import RecordLayer
 from .defragmenter import Defragmenter
+from .handshakehashes import HandshakeHashes
 
 import socket
 import traceback
@@ -119,9 +120,7 @@ class TLSRecordLayer(object):
         self.clearWriteBuffer()
 
         #Handshake digests
-        self._handshake_md5 = hashlib.md5()
-        self._handshake_sha = hashlib.sha1()
-        self._handshake_sha256 = hashlib.sha256()
+        self._handshake_hash = HandshakeHashes()
 
         #Is the connection open?
         self.closed = True #read-only
@@ -561,9 +560,7 @@ class TLSRecordLayer(object):
         contentType = msg.contentType
         #Update handshake hashes
         if contentType == ContentType.handshake:
-            self._handshake_md5.update(compat26Str(buf))
-            self._handshake_sha.update(compat26Str(buf))
-            self._handshake_sha256.update(compat26Str(buf))
+            self._handshake_hash.update(buf)
 
         #Fragment big messages
         while len(buf) > self.recordSize:
@@ -745,9 +742,7 @@ class TLSRecordLayer(object):
                             yield result
 
                 #Update handshake hashes
-                self._handshake_md5.update(compat26Str(p.bytes))
-                self._handshake_sha.update(compat26Str(p.bytes))
-                self._handshake_sha256.update(compat26Str(p.bytes))
+                self._handshake_hash.update(p.bytes)
 
                 #Parse based on handshake type
                 if subType == HandshakeType.client_hello:
@@ -874,9 +869,7 @@ class TLSRecordLayer(object):
         if not self.closed:
             raise ValueError("Renegotiation disallowed for security reasons")
         self._client = client
-        self._handshake_md5 = hashlib.md5()
-        self._handshake_sha = hashlib.sha1()
-        self._handshake_sha256 = hashlib.sha256()
+        self._handshake_hash = HandshakeHashes()
         self._defragmenter.clearBuffers()
         self.allegedSrpUsername = None
         self._refCount = 1
@@ -896,19 +889,3 @@ class TLSRecordLayer(object):
 
     def _changeReadState(self):
         self._recordLayer.changeReadState()
-
-    #Used for Finished messages and CertificateVerify messages in SSL v3
-    def _calcSSLHandshakeHash(self, masterSecret, label):
-        imac_md5 = self._handshake_md5.copy()
-        imac_sha = self._handshake_sha.copy()
-
-        imac_md5.update(compatHMAC(label + masterSecret + bytearray([0x36]*48)))
-        imac_sha.update(compatHMAC(label + masterSecret + bytearray([0x36]*40)))
-
-        md5Bytes = MD5(masterSecret + bytearray([0x5c]*48) + \
-                         bytearray(imac_md5.digest()))
-        shaBytes = SHA1(masterSecret + bytearray([0x5c]*40) + \
-                         bytearray(imac_sha.digest()))
-
-        return md5Bytes + shaBytes
-

--- a/unit_tests/test_tlslite_handshakehashes.py
+++ b/unit_tests/test_tlslite_handshakehashes.py
@@ -1,0 +1,98 @@
+# Copyright (c) 2014, Hubert Kario
+#
+# See the LICENSE file for legal information regarding use of this file.
+
+# compatibility with Python 2.6, for that we need unittest2 package,
+# which is not available on 3.3 or 3.4
+try:
+    import unittest2 as unittest
+except ImportError:
+    import unittest
+
+from tlslite.handshakehashes import HandshakeHashes
+
+class TestHandshakeHashes(unittest.TestCase):
+    def test___init__(self):
+        hh = HandshakeHashes()
+
+        self.assertIsNotNone(hh)
+
+    def test_update(self):
+        hh = HandshakeHashes()
+        hh.update(bytearray(10))
+
+    def test_update_with_str(self):
+        hh = HandshakeHashes()
+        hh.update(b'text')
+
+    def test_digest_SSL3(self):
+        hh = HandshakeHashes()
+
+        self.assertEqual(bytearray(
+                b'\xb5Q\x15\xa4\xcd\xff\xfdF\xa6\x9c\xe2\x0f\x83~\x948\xc3\xb5'\
+                b'\xc1\x8d\xb6|\x10n@a\x97\xccG\xfeI\xa8s T\\'),
+                hh.digestSSL(bytearray(48), b''))
+
+    def test_digest_TLS1_0(self):
+        hh = HandshakeHashes()
+
+        self.assertEqual(
+                b'\xd4\x1d\x8c\xd9\x8f\x00\xb2\x04\xe9\x80\t\x98\xec\xf8B~\xda'\
+                b'9\xa3\xee^kK\r2U\xbf\xef\x95`\x18\x90\xaf\xd8\x07\t',
+                hh.digest())
+
+    def test_copy(self):
+        hh = HandshakeHashes()
+        hh.update(b'text')
+
+        hh2 = hh.copy()
+
+        self.assertEqual(hh2.digest(), hh.digest())
+
+    def test_digest_md5(self):
+        hh = HandshakeHashes()
+
+        self.assertEqual(
+                b"\xd4\x1d\x8c\xd9\x8f\x00\xb2\x04\xe9\x80\t\x98\xec\xf8B~",
+                hh.digest('md5'))
+
+    def test_digest_sha1(self):
+        hh = HandshakeHashes()
+
+        self.assertEqual(
+                b"\xda9\xa3\xee^kK\r2U\xbf\xef\x95`\x18\x90\xaf\xd8\x07\t",
+                hh.digest('sha1'))
+
+    def test_digest_sha256(self):
+        hh = HandshakeHashes()
+
+        self.assertEqual(
+                b"\xe3\xb0\xc4B\x98\xfc\x1c\x14\x9a\xfb\xf4\xc8\x99o\xb9$'\xae"\
+                b"A\xe4d\x9b\x93L\xa4\x95\x99\x1bxR\xb8U",
+                hh.digest('sha256'))
+
+    def test_digest_with_partial_writes(self):
+        hh = HandshakeHashes()
+        hh.update(b'text')
+
+        hh2 = HandshakeHashes()
+        hh2.update(b'te')
+        hh2.update(b'xt')
+
+        self.assertEqual(hh.digest(), hh2.digest())
+
+    def test_digest_with_invalid_hash(self):
+        hh = HandshakeHashes()
+
+        with self.assertRaises(ValueError):
+            hh.digest('md2')
+
+    def test_digest_with_repeated_calls(self):
+        hh = HandshakeHashes()
+        hh.update(b'text')
+
+        self.assertEqual(hh.digest(), hh.digest())
+
+        hh.update(b'ext')
+
+        self.assertEqual(hh.digest('sha256'), hh.digest('sha256'))

--- a/unit_tests/test_tlslite_messages.py
+++ b/unit_tests/test_tlslite_messages.py
@@ -634,6 +634,24 @@ class TestServerHello(unittest.TestCase):
         self.assertEqual(None, server_hello.tackExt)
         self.assertEqual(None, server_hello.next_protos_advertised)
 
+    def test_create_with_minimal_options(self):
+        server_hello = ServerHello().create(
+                (3, 3),                                 # server version
+                bytearray(b'\x02'*31+b'\x01'),          # random
+                bytearray(4),                           # session ID
+                CipherSuite.TLS_RSA_WITH_RC4_128_MD5)   # ciphersuite
+
+        self.assertEqual(bytearray(
+            b'\x02' +                   # type of message
+            b'\x00\x00\x2a' +           # length
+            b'\x03\x03' +               # server version
+            b'\x02'*31+b'\x01' +        # random
+            b'\x04' +                   # Session ID length
+            b'\x00'*4 +                 # session id
+            b'\x00\x04' +               # selected ciphersuite
+            b'\x00'                     # selected compression method
+            ), server_hello.write())
+
     def test_parse(self):
         p = Parser(bytearray(
             # don't include type of message as it is handled by the hello

--- a/unit_tests/test_tlslite_messagesocket.py
+++ b/unit_tests/test_tlslite_messagesocket.py
@@ -1,0 +1,444 @@
+# Copyright (c) 2015, Hubert Kario
+#
+# See the LICENSE file for legal information regarding use of this file.
+
+# compatibility with Python 2.6, for that we need unittest2 package,
+# which is not available on 3.3 or 3.4
+try:
+    import unittest2 as unittest
+except ImportError:
+    import unittest
+
+from unit_tests.mocksock import MockSocket
+from tlslite.messagesocket import MessageSocket
+from tlslite.defragmenter import Defragmenter
+from tlslite.messages import Message
+from tlslite.constants import ContentType
+
+class TestMessageSocket(unittest.TestCase):
+    def test___init__(self):
+        msgSock = MessageSocket(None, None)
+
+        self.assertIsNotNone(msgSock)
+
+    def test_recvMessage(self):
+        defragmenter = Defragmenter()
+        defragmenter.addStaticSize(21, 2)
+
+        sock = MockSocket(bytearray(
+            b'\x15' +           # message type
+            b'\x03\x03' +       # TLS version
+            b'\x00\x04' +       # payload length
+            b'\xff\xff' +       # first message
+            b'\xbb\xbb'         # second message
+            ))
+
+        msgSock = MessageSocket(sock, defragmenter)
+
+        for res in msgSock.recvMessage():
+            if res in (0, 1):
+                self.assertTrue(False, "Blocking read")
+            else:
+                break
+
+        self.assertIsNotNone(res)
+
+        header, parser = res
+
+        self.assertEqual(header.type, 21)
+        self.assertEqual(header.version, (3, 3))
+        self.assertEqual(header.length, 0)
+        self.assertEqual(parser.bytes, bytearray(b'\xff\xff'))
+
+        res = None
+
+        for res in msgSock.recvMessage():
+            if res in (0, 1):
+                self.assertTrue(False, "Blocking read")
+            else:
+                break
+
+        self.assertIsNotNone(res)
+
+        header, parser = res
+
+        self.assertEqual(header.type, 21)
+        self.assertEqual(header.version, (3, 3))
+        self.assertEqual(header.length, 0)
+        self.assertEqual(parser.bytes, bytearray(b'\xbb\xbb'))
+
+    def test_recvMessage_with_unfragmentable_type(self):
+        defragmenter = Defragmenter()
+        defragmenter.addStaticSize(21, 2)
+
+        sock = MockSocket(bytearray(
+            b'\x17' +       # message type
+            b'\x03\x03' +   # TLS version
+            b'\x00\x06' +   # payload length
+            b'\x00\x04' +
+            b'\xff'*4
+            ))
+
+        msgSock = MessageSocket(sock, defragmenter)
+
+        for res in msgSock.recvMessage():
+            if res in (0, 1):
+                self.assertTrue(False, "Blocking read")
+            else:
+                break
+
+        self.assertIsNotNone(res)
+
+        header, parser = res
+
+        self.assertEqual(header.type, 23)
+        self.assertEqual(header.version, (3, 3))
+        self.assertEqual(header.length, 6)
+        self.assertEqual(parser.bytes, bytearray(b'\x00\x04' + b'\xff'*4))
+
+    def test_recvMessage_with_blocking_socket(self):
+        defragmenter = Defragmenter()
+        defragmenter.addStaticSize(21, 2)
+
+        sock = MockSocket(bytearray(
+            b'\x15' +           # message type
+            b'\x03\x03' +       # TLS version
+            b'\x00\x02' +       # payload length
+            b'\xff\xff'         # message
+            ),
+            blockEveryOther=True,
+            maxRet=1)
+
+        msgSock = MessageSocket(sock, defragmenter)
+
+        gotBlocked = False
+        for res in msgSock.recvMessage():
+            if res in (0, 1):
+                gotBlocked = True
+            else:
+                break
+
+        self.assertTrue(gotBlocked)
+        self.assertIsNotNone(res)
+
+        header, parser = res
+
+        self.assertEqual(header.type, 21)
+        self.assertEqual(header.version, (3, 3))
+        self.assertEqual(parser.bytes, bytearray(b'\xff\xff'))
+
+    def test_recvMessageBlocking(self):
+        defragmenter = Defragmenter()
+        defragmenter.addStaticSize(21, 2)
+
+        sock = MockSocket(bytearray(
+            b'\x15' +           # message type
+            b'\x03\x03' +       # TLS version
+            b'\x00\x02' +       # payload length
+            b'\xff\xff'         # message
+            ),
+            blockEveryOther=True,
+            maxRet=1)
+
+        msgSock = MessageSocket(sock, defragmenter)
+
+        res = msgSock.recvMessageBlocking()
+
+        self.assertIsNotNone(res)
+
+        header, parser = res
+
+        self.assertEqual(header.type, 21)
+        self.assertEqual(parser.bytes, bytearray(b'\xff\xff'))
+
+    def test_flush(self):
+        sock = MockSocket(bytearray())
+
+        msgSock = MessageSocket(sock, None)
+
+        for res in msgSock.flush():
+            if res in (0, 1):
+                self.assertTrue(False, "Blocking flush")
+            else:
+                break
+
+        self.assertEqual(len(sock.sent), 0)
+
+        for res in msgSock.flush():
+            if res in (0, 1):
+                self.assertTrue(False, "Blocking flush")
+            else:
+                break
+
+        self.assertEqual(len(sock.sent), 0)
+
+    def test_queueMessage(self):
+        sock = MockSocket(bytearray())
+
+        msgSocket = MessageSocket(sock, None)
+
+        msg = Message(ContentType.alert, bytearray(b'\xff\xbb'))
+
+        for res in msgSocket.queueMessage(msg):
+            if res in (0, 1):
+                self.assertTrue(False, "Blocking queue")
+            else:
+                break
+
+        self.assertEqual(len(sock.sent), 0)
+
+        msg = Message(ContentType.alert, bytearray(b'\xff\xaa'))
+
+        for res in msgSocket.queueMessage(msg):
+            if res in (0, 1):
+                self.assertTrue(False, "Blocking queue")
+            else:
+                break
+
+        self.assertEqual(len(sock.sent), 0)
+
+        for res in msgSocket.flush():
+            if res in (0, 1):
+                self.assertTrue(False, "Blocking flush")
+            else:
+                break
+
+        self.assertEqual(len(sock.sent), 1)
+        self.assertEqual(sock.sent[0], bytearray(
+            b'\x15' +
+            b'\x00\x00' +
+            b'\x00\x04' +
+            b'\xff\xbb' +
+            b'\xff\xaa'))
+
+    def test_queueMessage_with_conflicting_types(self):
+        sock = MockSocket(bytearray())
+
+        msgSock = MessageSocket(sock, None)
+        msgSock.version = (3, 3)
+
+        msg = Message(ContentType.handshake, bytearray(b'\xaa\xaa\xaa'))
+
+        for res in msgSock.queueMessage(msg):
+            if res in (0, 1):
+                self.assertTrue(False, "Blocking queue")
+            else:
+                break
+
+        self.assertEqual(len(sock.sent), 0)
+
+        msg = Message(ContentType.alert, bytearray(b'\x02\x01'))
+
+        for res in msgSock.queueMessage(msg):
+            if res in (0, 1):
+                self.assertTrue(False, "Blocking queue")
+            else:
+                break
+
+        self.assertEqual(len(sock.sent), 1)
+        self.assertEqual(bytearray(
+            b'\x16' +
+            b'\x03\x03' +
+            b'\x00\x03' +
+            b'\xaa'*3), sock.sent[0])
+
+        for res in msgSock.flush():
+            if res in (0, 1):
+                self.assertTrue(False, "Blocking flush")
+            else:
+                break
+
+        self.assertEqual(len(sock.sent), 2)
+        self.assertEqual(bytearray(
+            b'\x15' +
+            b'\x03\x03' +
+            b'\x00\x02' +
+            b'\x02\x01'), sock.sent[1])
+
+    def test_queueMessage_with_conflicting_types_and_blocking_socket(self):
+        sock = MockSocket(bytearray(), blockEveryOther=True)
+        sock.blockWrite = True
+
+        msgSock = MessageSocket(sock, None)
+        msgSock.version = (3, 3)
+
+        msg = Message(ContentType.handshake, bytearray(b'\xaa\xaa\xaa'))
+
+        blocked = False
+        for res in msgSock.queueMessage(msg):
+            if res in (0, 1):
+                blocked = True
+            else:
+                break
+
+        # no write so no blocking
+        self.assertFalse(blocked)
+        self.assertEqual(len(sock.sent), 0)
+
+        msg = Message(ContentType.alert, bytearray(b'\x02\x01'))
+
+        blocked = False
+        for res in msgSock.queueMessage(msg):
+            if res in (0, 1):
+                blocked = True
+            else:
+                break
+
+        # blocked once, so one write
+        self.assertTrue(blocked)
+        self.assertEqual(len(sock.sent), 1)
+        self.assertEqual(bytearray(
+            b'\x16' +
+            b'\x03\x03' +
+            b'\x00\x03' +
+            b'\xaa'*3), sock.sent[0])
+
+        sock.blockWrite = True
+
+        blocked = False
+        for res in msgSock.flush():
+            if res in (0, 1):
+                blocked = True
+            else:
+                break
+
+        # blocked once, so one write
+        self.assertTrue(blocked)
+        self.assertEqual(len(sock.sent), 2)
+        self.assertEqual(bytearray(
+            b'\x15' +
+            b'\x03\x03' +
+            b'\x00\x02' +
+            b'\x02\x01'), sock.sent[1])
+
+    def test_sendMessage(self):
+        sock = MockSocket(bytearray(), blockEveryOther=True)
+        sock.blockWrite = True
+
+        msgSock = MessageSocket(sock, None)
+        msgSock.version = (3, 3)
+
+        msg = Message(ContentType.handshake, bytearray(b'\xaa\xaa\xaa'))
+
+        blocked = False
+        for res in msgSock.queueMessage(msg):
+            if res in (0, 1):
+                blocked = True
+            else:
+                break
+
+        # no write so no blocking
+        self.assertFalse(blocked)
+        self.assertEqual(len(sock.sent), 0)
+
+        msg = Message(ContentType.alert, bytearray(b'\x02\x01'))
+
+        blocked = False
+        for res in msgSock.sendMessage(msg):
+            if res in (0, 1):
+                blocked = True
+            else:
+                break
+
+        self.assertTrue(blocked)
+        self.assertEqual(len(sock.sent), 2)
+        self.assertEqual(bytearray(
+            b'\x16' +
+            b'\x03\x03' +
+            b'\x00\x03' +
+            b'\xaa'*3), sock.sent[0])
+        self.assertEqual(bytearray(
+            b'\x15' +
+            b'\x03\x03' +
+            b'\x00\x02' +
+            b'\x02\x01'), sock.sent[1])
+
+    def test_sendMessageBlocking(self):
+        sock = MockSocket(bytearray(), blockEveryOther=True)
+        sock.blockWrite = True
+
+        msgSock = MessageSocket(sock, None)
+        msgSock.version = (3, 3)
+
+        msg = Message(ContentType.handshake, bytearray(b'\xaa\xaa\xaa'))
+
+        blocked = False
+        for res in msgSock.queueMessage(msg):
+            if res in (0, 1):
+                blocked = True
+            else:
+                break
+
+        # no write so no blocking
+        self.assertFalse(blocked)
+        self.assertEqual(len(sock.sent), 0)
+
+        msg = Message(ContentType.alert, bytearray(b'\x02\x01'))
+
+        msgSock.sendMessageBlocking(msg)
+
+        self.assertEqual(len(sock.sent), 2)
+        self.assertEqual(bytearray(
+            b'\x16' +
+            b'\x03\x03' +
+            b'\x00\x03' +
+            b'\xaa'*3), sock.sent[0])
+        self.assertEqual(bytearray(
+            b'\x15' +
+            b'\x03\x03' +
+            b'\x00\x02' +
+            b'\x02\x01'), sock.sent[1])
+
+    def test_queueMessageBlocking(self):
+        sock = MockSocket(bytearray(), blockEveryOther=True)
+        sock.blockWrite = True
+
+        msgSock = MessageSocket(sock, None)
+        msgSock.version = (3, 3)
+
+        msg = Message(ContentType.handshake, bytearray(b'\xaa\xaa\xaa'))
+
+        msgSock.queueMessageBlocking(msg)
+
+        self.assertEqual(len(sock.sent), 0)
+
+        msg = Message(ContentType.alert, bytearray(b'\x02\x01'))
+
+        msgSock.queueMessageBlocking(msg)
+
+        self.assertEqual(len(sock.sent), 1)
+        self.assertEqual(bytearray(
+            b'\x16' +
+            b'\x03\x03' +
+            b'\x00\x03' +
+            b'\xaa'*3), sock.sent[0])
+
+    def test_flushBlocking(self):
+        sock = MockSocket(bytearray())
+        msgSock = MessageSocket(sock, None)
+
+        msgSock.flushBlocking()
+
+        self.assertEqual(len(sock.sent), 0)
+
+    def test_flushBlocking_with_data(self):
+        sock = MockSocket(bytearray(), blockEveryOther=True)
+        sock.blockWrite = True
+
+        msgSock = MessageSocket(sock, None)
+        msgSock.version = (3, 3)
+
+        msg = Message(ContentType.handshake, bytearray(b'\xaa\xaa\xaa'))
+
+        msgSock.queueMessageBlocking(msg)
+
+        self.assertEqual(len(sock.sent), 0)
+
+        msgSock.flushBlocking()
+
+        self.assertEqual(len(sock.sent), 1)
+        self.assertEqual(bytearray(
+            b'\x16' +
+            b'\x03\x03' +
+            b'\x00\x03' +
+            b'\xaa'*3), sock.sent[0])

--- a/unit_tests/test_tlslite_recordlayer.py
+++ b/unit_tests/test_tlslite_recordlayer.py
@@ -331,13 +331,13 @@ class TestRecordLayer(unittest.TestCase):
         self.assertIsNone(recordLayer.getCipherImplementation())
         self.assertFalse(recordLayer.isCBCMode())
 
-    def test_sendMessage(self):
+    def test_sendRecord(self):
         sock = MockSocket(bytearray(0))
         recordLayer = RecordLayer(sock)
 
         hello = Message(ContentType.handshake, bytearray(10))
 
-        for result in recordLayer.sendMessage(hello):
+        for result in recordLayer.sendRecord(hello):
             if result in (0, 1):
                 self.assertTrue(False, "Blocking write")
             else:
@@ -388,7 +388,7 @@ class TestRecordLayer(unittest.TestCase):
         else:
             self.assertEqual('python', recordLayer.getCipherImplementation())
 
-    def test_sendMessage_with_encrypting_set_up_tls1_2(self):
+    def test_sendRecord_with_encrypting_set_up_tls1_2(self):
         patcher = mock.patch.object(os,
                                     'urandom',
                                     lambda x: bytearray(x))
@@ -412,7 +412,7 @@ class TestRecordLayer(unittest.TestCase):
         self.assertIsNotNone(app_data)
         self.assertTrue(len(app_data.write()) > 3)
 
-        for result in recordLayer.sendMessage(app_data):
+        for result in recordLayer.sendRecord(app_data):
             if result in (0, 1):
                 self.assertTrue(False, "blocking socket")
             else: break
@@ -429,7 +429,7 @@ class TestRecordLayer(unittest.TestCase):
             b'\x9f\x73\xec\xa9\xa6\x82\x55\x8e\x3a\x8c\x94\x96\xda\x06\x09\x8d'
             ), sock.sent[0][5:])
 
-    def test_sendMessage_with_SHA256_tls1_2(self):
+    def test_sendRecord_with_SHA256_tls1_2(self):
         patcher = mock.patch.object(os,
                                     'urandom',
                                     lambda x: bytearray(x))
@@ -454,7 +454,7 @@ class TestRecordLayer(unittest.TestCase):
         self.assertIsNotNone(app_data)
         self.assertTrue(len(app_data.write()) > 3)
 
-        for result in recordLayer.sendMessage(app_data):
+        for result in recordLayer.sendRecord(app_data):
             if result in (0, 1):
                 self.assertTrue(False, "blocking socket")
             else: break
@@ -472,7 +472,7 @@ class TestRecordLayer(unittest.TestCase):
             b'\xe0"c:7\xa9\xd7}X\x00[\x88\xce\xfe|\t'
             ), sock.sent[0][5:])
 
-    def test_sendMessage_with_encrypting_set_up_tls1_1(self):
+    def test_sendRecord_with_encrypting_set_up_tls1_1(self):
         patcher = mock.patch.object(os,
                                     'urandom',
                                     lambda x: bytearray(x))
@@ -496,7 +496,7 @@ class TestRecordLayer(unittest.TestCase):
         self.assertIsNotNone(app_data)
         self.assertTrue(len(app_data.write()) > 3)
 
-        for result in recordLayer.sendMessage(app_data):
+        for result in recordLayer.sendRecord(app_data):
             if result in (0, 1):
                 self.assertTrue(False, "blocking socket")
             else: break
@@ -513,7 +513,7 @@ class TestRecordLayer(unittest.TestCase):
             b'\xa8\x8c!k\xab\x03\x03\x19.\x1dFMt\x08h^'
             ), sock.sent[0][5:])
 
-    def test_sendMessage_with_encrypting_set_up_tls1_0(self):
+    def test_sendRecord_with_encrypting_set_up_tls1_0(self):
         sock = MockSocket(bytearray(0))
 
         recordLayer = RecordLayer(sock)
@@ -531,7 +531,7 @@ class TestRecordLayer(unittest.TestCase):
         self.assertIsNotNone(app_data)
         self.assertTrue(len(app_data.write()) > 3)
 
-        for result in recordLayer.sendMessage(app_data):
+        for result in recordLayer.sendRecord(app_data):
             if result in (0, 1):
                 self.assertTrue(False, "blocking socket")
             else: break
@@ -547,7 +547,7 @@ class TestRecordLayer(unittest.TestCase):
             b'D\xe9\xec\x8d\xdfd\xed\x94\x9f\xe6K\x08(\x08\xf6\xb7'
             ))
 
-    def test_sendMessage_with_stream_cipher_and_tls1_0(self):
+    def test_sendRecord_with_stream_cipher_and_tls1_0(self):
         sock = MockSocket(bytearray(0))
 
         recordLayer = RecordLayer(sock)
@@ -565,7 +565,7 @@ class TestRecordLayer(unittest.TestCase):
         self.assertIsNotNone(app_data)
         self.assertTrue(len(app_data.write()) > 3)
 
-        for result in recordLayer.sendMessage(app_data):
+        for result in recordLayer.sendRecord(app_data):
             if result in (0, 1):
                 self.assertTrue(False, "blocking socket")
             else: break
@@ -581,7 +581,7 @@ class TestRecordLayer(unittest.TestCase):
             b'\xa1\xaf]Q%y5\x1e'
             ))
 
-    def test_sendMessage_with_MD5_MAC_and_tls1_0(self):
+    def test_sendRecord_with_MD5_MAC_and_tls1_0(self):
         sock = MockSocket(bytearray(0))
 
         recordLayer = RecordLayer(sock)
@@ -599,7 +599,7 @@ class TestRecordLayer(unittest.TestCase):
         self.assertIsNotNone(app_data)
         self.assertTrue(len(app_data.write()) > 3)
 
-        for result in recordLayer.sendMessage(app_data):
+        for result in recordLayer.sendRecord(app_data):
             if result in (0, 1):
                 self.assertTrue(False, "blocking socket")
             else: break
@@ -616,7 +616,7 @@ class TestRecordLayer(unittest.TestCase):
             ))
 
 
-    def test_sendMessage_with_AES256_cipher_and_tls1_0(self):
+    def test_sendRecord_with_AES256_cipher_and_tls1_0(self):
         sock = MockSocket(bytearray(0))
 
         recordLayer = RecordLayer(sock)
@@ -634,7 +634,7 @@ class TestRecordLayer(unittest.TestCase):
         self.assertIsNotNone(app_data)
         self.assertTrue(len(app_data.write()) > 3)
 
-        for result in recordLayer.sendMessage(app_data):
+        for result in recordLayer.sendRecord(app_data):
             if result in (0, 1):
                 self.assertTrue(False, "blocking socket")
             else: break
@@ -653,7 +653,7 @@ class TestRecordLayer(unittest.TestCase):
     # tlslite has no pure python implementation of 3DES
     @unittest.skipUnless(cryptomath.m2cryptoLoaded or cryptomath.pycryptoLoaded,
                          "requires native 3DES implementation")
-    def test_sendMessage_with_3DES_cipher_and_tls1_0(self):
+    def test_sendRecord_with_3DES_cipher_and_tls1_0(self):
         sock = MockSocket(bytearray(0))
 
         recordLayer = RecordLayer(sock)
@@ -671,7 +671,7 @@ class TestRecordLayer(unittest.TestCase):
         self.assertIsNotNone(app_data)
         self.assertTrue(len(app_data.write()) > 3)
 
-        for result in recordLayer.sendMessage(app_data):
+        for result in recordLayer.sendRecord(app_data):
             if result in (0, 1):
                 self.assertTrue(False, "blocking socket")
             else: break
@@ -687,7 +687,7 @@ class TestRecordLayer(unittest.TestCase):
             b'\x8d\x16\x8b\xa3N\xe6\xfa\x14\xa9\xb9\xc7\x08w\xf2V\xe2'
             ))
 
-    def test_sendMessage_with_encrypting_set_up_ssl3(self):
+    def test_sendRecord_with_encrypting_set_up_ssl3(self):
         sock = MockSocket(bytearray(0))
 
         recordLayer = RecordLayer(sock)
@@ -705,7 +705,7 @@ class TestRecordLayer(unittest.TestCase):
         self.assertIsNotNone(app_data)
         self.assertTrue(len(app_data.write()) > 3)
 
-        for result in recordLayer.sendMessage(app_data):
+        for result in recordLayer.sendRecord(app_data):
             if result in (0, 1):
                 self.assertTrue(False, "blocking socket")
             else: break
@@ -721,7 +721,7 @@ class TestRecordLayer(unittest.TestCase):
             b'\xff\x842\xc7\xa2\x0byd\xab\x1a\xfd\xaf\x05\xd6\xba\x89'
             ))
 
-    def test_sendMessage_with_wrong_SSL_version(self):
+    def test_sendRecord_with_wrong_SSL_version(self):
         sock = MockSocket(bytearray(0))
 
         recordLayer = RecordLayer(sock)
@@ -734,7 +734,7 @@ class TestRecordLayer(unittest.TestCase):
                     bytearray(32), # server random
                     None)
 
-    def test_sendMessage_with_invalid_ciphersuite(self):
+    def test_sendRecord_with_invalid_ciphersuite(self):
         sock = MockSocket(bytearray(0))
 
         recordLayer = RecordLayer(sock)
@@ -747,14 +747,14 @@ class TestRecordLayer(unittest.TestCase):
                     bytearray(32), # server random
                     None)
 
-    def test_sendMessage_with_slow_socket(self):
+    def test_sendRecord_with_slow_socket(self):
         mockSock = MockSocket(bytearray(0), maxWrite=1, blockEveryOther=True)
         sock = RecordLayer(mockSock)
 
         msg = Message(ContentType.handshake, bytearray(b'\x32'*2))
 
         gotRetry = False
-        for result in sock.sendMessage(msg):
+        for result in sock.sendRecord(msg):
             if result in (0, 1):
                 gotRetry = True
             else: break
@@ -767,7 +767,7 @@ class TestRecordLayer(unittest.TestCase):
             bytearray(b'\x32'), bytearray(b'\x32')],
             mockSock.sent)
 
-    def test_sendMessage_with_encryptThenMAC_and_unset_crypto_state(self):
+    def test_sendRecord_with_encryptThenMAC_and_unset_crypto_state(self):
         sock = MockSocket(bytearray(0))
         recordLayer = RecordLayer(sock)
         recordLayer.version = (3, 1)
@@ -775,7 +775,7 @@ class TestRecordLayer(unittest.TestCase):
 
         app_data = ApplicationData().create(bytearray(b'test'))
 
-        for result in recordLayer.sendMessage(app_data):
+        for result in recordLayer.sendRecord(app_data):
             if result in (0, 1):
                 self.assertTrue(False, "blocking socket")
             else: break
@@ -787,7 +787,7 @@ class TestRecordLayer(unittest.TestCase):
             b'\x00\x04' +       # length
             b'test'), sock.sent[0])
 
-    def test_sendMessage_with_encryptThenMAC_in_TLSv1_0(self):
+    def test_sendRecord_with_encryptThenMAC_in_TLSv1_0(self):
         sock = MockSocket(bytearray(0))
         recordLayer = RecordLayer(sock)
         recordLayer.version = (3, 1)
@@ -801,7 +801,7 @@ class TestRecordLayer(unittest.TestCase):
 
         app_data = ApplicationData().create(bytearray(b'test'))
 
-        for result in recordLayer.sendMessage(app_data):
+        for result in recordLayer.sendRecord(app_data):
             if result in (0, 1):
                 self.assertTrue(False, "blocking socket")
             else: break
@@ -815,7 +815,7 @@ class TestRecordLayer(unittest.TestCase):
             b'X\xcd\xdc\'o\xb3I\xdd-\xfc\tneq~\x0f' +
             b'd\xdb\xbdw'), sock.sent[0])
 
-    def test_sendMessage_with_encryptThenMAC_in_TLSv1_2(self):
+    def test_sendRecord_with_encryptThenMAC_in_TLSv1_2(self):
         patcher = mock.patch.object(os,
                                     'urandom',
                                     lambda x: bytearray(x))
@@ -835,7 +835,7 @@ class TestRecordLayer(unittest.TestCase):
 
         app_data = ApplicationData().create(bytearray(b'test'))
 
-        for result in recordLayer.sendMessage(app_data):
+        for result in recordLayer.sendRecord(app_data):
             if result in (0, 1):
                 self.assertTrue(False, "blocking socket")
             else: break
@@ -904,7 +904,7 @@ class TestRecordLayer(unittest.TestCase):
             b'\x17' +           # application data
             b'\x03\x02' +       # TLSv1.1
             b'\x00\x30' +       # length
-            # data from test_sendMessage_with_encrypting_set_up_tls1_1
+            # data from test_sendRecord_with_encrypting_set_up_tls1_1
             b'b\x8e\xee\xddV\\W=\x810\xd5\x0c\xae \x84\xa8' +
             b'^\x91\xa4d[\xe4\xde\x90\xee{f\xbb\xcd_\x1ao' +
             b'\xa8\x8c!k\xab\x03\x03\x19.\x1dFMt\x08h^'
@@ -938,7 +938,7 @@ class TestRecordLayer(unittest.TestCase):
             b'\x17' +           # application data
             b'\x03\x00' +       # SSLv3
             b'\x00\x20' +       # length
-            # data from test_sendMessage_with_encrypting_set_up_ssl3
+            # data from test_sendRecord_with_encrypting_set_up_ssl3
             b'\xc5\x16y\xf9\ra\xd9=\xec\x8b\x93\'\xb7\x05\xe6\xad' +
             b'\xff\x842\xc7\xa2\x0byd\xab\x1a\xfd\xaf\x05\xd6\xba\x89'
             ))
@@ -971,7 +971,7 @@ class TestRecordLayer(unittest.TestCase):
             b'\x17' +           # application data
             b'\x03\x01' +       # TLSv1.0
             b'\x00\x18' +       # length (24 bytes)
-            # data from test_sendMessage_with_stream_cipher_and_tls1_0
+            # data from test_sendRecord_with_stream_cipher_and_tls1_0
             b'B\xb8H\xc6\xd7\\\x01\xe27\xa9\x86\xf2\xfdm!\x1d' +
             b'\xa1\xaf]Q%y5\x1e'
             ))
@@ -1060,7 +1060,7 @@ class TestRecordLayer(unittest.TestCase):
         msg = ApplicationData().create(bytearray(b'test'))
 
         # create the data
-        for result in sendingRecordLayer.sendMessage(msg):
+        for result in sendingRecordLayer.sendRecord(msg):
             if result in (0, 1):
                 self.assertTrue(False, "Blocking socket")
             else:
@@ -1138,7 +1138,7 @@ class TestRecordLayer(unittest.TestCase):
         msg = ApplicationData().create(bytearray(b'test'))
 
         # create the bad data
-        for result in sendingRecordLayer.sendMessage(msg):
+        for result in sendingRecordLayer.sendRecord(msg):
             if result in (0, 1):
                 self.assertTrue(False, "Blocking socket")
             else:
@@ -1210,7 +1210,7 @@ class TestRecordLayer(unittest.TestCase):
         msg = ApplicationData().create(bytearray(b'test'))
 
         # create the bad data
-        for result in sendingRecordLayer.sendMessage(msg):
+        for result in sendingRecordLayer.sendRecord(msg):
             if result in (0, 1):
                 self.assertTrue(False, "Blocking socket")
             else:
@@ -1281,7 +1281,7 @@ class TestRecordLayer(unittest.TestCase):
         msg = ApplicationData().create(bytearray(b'test'))
 
         # create the bad data
-        for result in sendingRecordLayer.sendMessage(msg):
+        for result in sendingRecordLayer.sendRecord(msg):
             if result in (0, 1):
                 self.assertTrue(False, "Blocking socket")
             else:
@@ -1352,7 +1352,7 @@ class TestRecordLayer(unittest.TestCase):
         msg = ApplicationData().create(bytearray(b'test'))
 
         # create the bad data
-        for result in sendingRecordLayer.sendMessage(msg):
+        for result in sendingRecordLayer.sendRecord(msg):
             if result in (0, 1):
                 self.assertTrue(False, "Blocking socket")
             else:
@@ -1407,7 +1407,7 @@ class TestRecordLayer(unittest.TestCase):
         self.assertEqual(parser.bytes, bytearray(b'test'))
 
     def test_recvMessage_with_encryptThenMAC_in_TLSv1_0(self):
-        # data from test_sendMessage_with_encryptThenMAC_in_TLSv1_0
+        # data from test_sendRecord_with_encryptThenMAC_in_TLSv1_0
         sock = MockSocket(bytearray(
             b'\x17' +           # application data
             b'\x03\x01' +       # TLS version
@@ -1438,7 +1438,7 @@ class TestRecordLayer(unittest.TestCase):
 
     def test_recvMessage_with_encryptThenMAC_in_TLSv1_2(self):
 
-        # data from test_sendMessage_with_encryptThenMAC_in_TLSv1_2
+        # data from test_sendRecord_with_encryptThenMAC_in_TLSv1_2
         sock = MockSocket(bytearray(
             b'\x17' +           # application data
             b'\x03\x03' +       # TLS version
@@ -1550,7 +1550,7 @@ class TestRecordLayer(unittest.TestCase):
         msg = ApplicationData().create(bytearray(b'test'))
 
         # create the bad data
-        for result in sendingRecordLayer.sendMessage(msg):
+        for result in sendingRecordLayer.sendRecord(msg):
             if result in (0, 1):
                 self.assertTrue(False, "Blocking socket")
             else:
@@ -1623,7 +1623,7 @@ class TestRecordLayer(unittest.TestCase):
         msg = ApplicationData().create(bytearray(b'test'))
 
         # create the bad data
-        for result in sendingRecordLayer.sendMessage(msg):
+        for result in sendingRecordLayer.sendRecord(msg):
             if result in (0, 1):
                 self.assertTrue(False, "Blocking socket")
             else:
@@ -1676,7 +1676,7 @@ class TestRecordLayer(unittest.TestCase):
         msg = ApplicationData().create(bytearray(b'test'))
 
         # create the data
-        for result in sendingRecordLayer.sendMessage(msg):
+        for result in sendingRecordLayer.sendRecord(msg):
             if result in (0, 1):
                 self.assertTrue(False, "Blocking socket")
             else:
@@ -1754,7 +1754,7 @@ class TestRecordLayer(unittest.TestCase):
         msg = ApplicationData().create(bytearray(b'test'))
 
         # create the bad data
-        for result in sendingRecordLayer.sendMessage(msg):
+        for result in sendingRecordLayer.sendRecord(msg):
             if result in (0, 1):
                 self.assertTrue(False, "Blocking socket")
             else:

--- a/unit_tests/test_tlslite_recordlayer.py
+++ b/unit_tests/test_tlslite_recordlayer.py
@@ -850,7 +850,7 @@ class TestRecordLayer(unittest.TestCase):
             b'\xa4\x9bH}T\xcbT\x9d2\xed\xc5\xe1|\x82T\xf1' +
             b'\xf6\x19\xfcw'), sock.sent[0])
 
-    def test_recvMessage(self):
+    def test_recvRecord(self):
         sock = MockSocket(bytearray(
             b'\x16' +           # handshake
             b'\x03\x03' +       # TLSv1.2
@@ -860,7 +860,7 @@ class TestRecordLayer(unittest.TestCase):
             ))
         recordLayer = RecordLayer(sock)
 
-        for result in recordLayer.recvMessage():
+        for result in recordLayer.recvRecord():
             if result in (0, 1):
                 self.assertTrue(False, "Blocking read")
             else:
@@ -873,7 +873,7 @@ class TestRecordLayer(unittest.TestCase):
         self.assertEqual((3, 3), header.version)
         self.assertEqual(bytearray(b'\x0e' + b'\x00'*3), parser.bytes)
 
-    def test_recvMessage_with_slow_socket(self):
+    def test_recvRecord_with_slow_socket(self):
         sock = MockSocket(bytearray(
             b'\x16' +           # handshake
             b'\x03\x03' +       # TLSv1.2
@@ -884,7 +884,7 @@ class TestRecordLayer(unittest.TestCase):
         recordLayer = RecordLayer(sock)
 
         wasBlocked = False
-        for result in recordLayer.recvMessage():
+        for result in recordLayer.recvRecord():
             if result in (0, 1):
                 wasBlocked = True
             else:
@@ -899,7 +899,7 @@ class TestRecordLayer(unittest.TestCase):
         self.assertEqual(bytearray(b'\x0e' + b'\x00'*3), parser.bytes)
 
 
-    def test_recvMessage_with_encrypted_content_TLS1_1(self):
+    def test_recvRecord_with_encrypted_content_TLS1_1(self):
         sock = MockSocket(bytearray(
             b'\x17' +           # application data
             b'\x03\x02' +       # TLSv1.1
@@ -920,7 +920,7 @@ class TestRecordLayer(unittest.TestCase):
                                       None)
         recordLayer.changeReadState()
 
-        for result in recordLayer.recvMessage():
+        for result in recordLayer.recvRecord():
             if result in (0, 1):
                 self.assertTrue(False, "Blocking read")
             else:
@@ -933,7 +933,7 @@ class TestRecordLayer(unittest.TestCase):
         self.assertEqual((3, 2), header.version)
         self.assertEqual(bytearray(b'test'), parser.bytes)
 
-    def test_recvMessage_with_encrypted_content_SSLv3(self):
+    def test_recvRecord_with_encrypted_content_SSLv3(self):
         sock = MockSocket(bytearray(
             b'\x17' +           # application data
             b'\x03\x00' +       # SSLv3
@@ -953,7 +953,7 @@ class TestRecordLayer(unittest.TestCase):
                                       None)
         recordLayer.changeReadState()
 
-        for result in recordLayer.recvMessage():
+        for result in recordLayer.recvRecord():
             if result in (0, 1):
                 self.assertTrue(False, "Blocking read")
             else:
@@ -966,7 +966,7 @@ class TestRecordLayer(unittest.TestCase):
         self.assertEqual((3, 0), header.version)
         self.assertEqual(bytearray(b'test'), parser.bytes)
 
-    def test_recvMessage_with_stream_cipher_and_tls1_0(self):
+    def test_recvRecord_with_stream_cipher_and_tls1_0(self):
         sock = MockSocket(bytearray(
             b'\x17' +           # application data
             b'\x03\x01' +       # TLSv1.0
@@ -986,7 +986,7 @@ class TestRecordLayer(unittest.TestCase):
                                       None)
         recordLayer.changeReadState()
 
-        for result in recordLayer.recvMessage():
+        for result in recordLayer.recvRecord():
             if result in (0, 1):
                 self.assertTrue(False, "Blocking read")
             else:
@@ -999,7 +999,7 @@ class TestRecordLayer(unittest.TestCase):
         self.assertEqual((3, 1), header.version)
         self.assertEqual(bytearray(b'test'), parser.bytes)
 
-    def test_recvMessage_with_invalid_length_payload(self):
+    def test_recvRecord_with_invalid_length_payload(self):
         sock = MockSocket(bytearray(
             b'\x17' +           # application data
             b'\x03\x02' +       # TLSv1.1
@@ -1019,12 +1019,12 @@ class TestRecordLayer(unittest.TestCase):
                                       None)
         recordLayer.changeReadState()
 
-        gen = recordLayer.recvMessage()
+        gen = recordLayer.recvRecord()
 
         with self.assertRaises(TLSDecryptionFailed):
             next(gen)
 
-    def test_recvMessage_with_zero_filled_padding_in_SSLv3(self):
+    def test_recvRecord_with_zero_filled_padding_in_SSLv3(self):
         # make sure the IV is predictible (all zero)
         patcher = mock.patch.object(os,
                                     'urandom',
@@ -1088,7 +1088,7 @@ class TestRecordLayer(unittest.TestCase):
                                       None)
         recordLayer.changeReadState()
 
-        for result in recordLayer.recvMessage():
+        for result in recordLayer.recvRecord():
             if result in (0, 1):
                 self.assertTrue(False, "Blocking socket")
             else: break
@@ -1100,7 +1100,7 @@ class TestRecordLayer(unittest.TestCase):
         self.assertEqual((3, 0), header.version)
         self.assertEqual(bytearray(b'test'), parser.bytes)
 
-    def test_recvMessage_with_invalid_last_byte_in_padding(self):
+    def test_recvRecord_with_invalid_last_byte_in_padding(self):
         # make sure the IV is predictible (all zero)
         patcher = mock.patch.object(os,
                                     'urandom',
@@ -1166,12 +1166,12 @@ class TestRecordLayer(unittest.TestCase):
                                       None)
         recordLayer.changeReadState()
 
-        gen = recordLayer.recvMessage()
+        gen = recordLayer.recvRecord()
 
         with self.assertRaises(TLSBadRecordMAC):
             next(gen)
 
-    def test_recvMessage_with_invalid_middle_byte_in_padding(self):
+    def test_recvRecord_with_invalid_middle_byte_in_padding(self):
         # make sure the IV is predictible (all zero)
         patcher = mock.patch.object(os,
                                     'urandom',
@@ -1238,12 +1238,12 @@ class TestRecordLayer(unittest.TestCase):
                                       None)
         recordLayer.changeReadState()
 
-        gen = recordLayer.recvMessage()
+        gen = recordLayer.recvRecord()
 
         with self.assertRaises(TLSBadRecordMAC):
             next(gen)
 
-    def test_recvMessage_with_truncated_MAC(self):
+    def test_recvRecord_with_truncated_MAC(self):
         # make sure the IV is predictible (all zero)
         patcher = mock.patch.object(os,
                                     'urandom',
@@ -1309,12 +1309,12 @@ class TestRecordLayer(unittest.TestCase):
                                       None)
         recordLayer.changeReadState()
 
-        gen = recordLayer.recvMessage()
+        gen = recordLayer.recvRecord()
 
         with self.assertRaises(TLSBadRecordMAC):
             next(gen)
 
-    def test_recvMessage_with_invalid_MAC(self):
+    def test_recvRecord_with_invalid_MAC(self):
         # make sure the IV is predictible (all zero)
         patcher = mock.patch.object(os,
                                     'urandom',
@@ -1380,12 +1380,12 @@ class TestRecordLayer(unittest.TestCase):
                                       None)
         recordLayer.changeReadState()
 
-        gen = recordLayer.recvMessage()
+        gen = recordLayer.recvRecord()
 
         with self.assertRaises(TLSBadRecordMAC):
             next(gen)
 
-    def test_recvMessage_with_encryptThenMAC_and_unset_crypto_state(self):
+    def test_recvRecord_with_encryptThenMAC_and_unset_crypto_state(self):
         sock = MockSocket(bytearray(
             b'\x17' +           # application data
             b'\x03\x01' +       # TLS version
@@ -1397,7 +1397,7 @@ class TestRecordLayer(unittest.TestCase):
         recordLayer.client = False
         recordLayer.encryptThenMAC = True
 
-        for result in recordLayer.recvMessage():
+        for result in recordLayer.recvRecord():
             if result in (0, 1):
                 self.assertTrue(False, "blocking socket")
             else: break
@@ -1406,7 +1406,7 @@ class TestRecordLayer(unittest.TestCase):
 
         self.assertEqual(parser.bytes, bytearray(b'test'))
 
-    def test_recvMessage_with_encryptThenMAC_in_TLSv1_0(self):
+    def test_recvRecord_with_encryptThenMAC_in_TLSv1_0(self):
         # data from test_sendRecord_with_encryptThenMAC_in_TLSv1_0
         sock = MockSocket(bytearray(
             b'\x17' +           # application data
@@ -1427,7 +1427,7 @@ class TestRecordLayer(unittest.TestCase):
                                       None)
         recordLayer.changeReadState()
 
-        for result in recordLayer.recvMessage():
+        for result in recordLayer.recvRecord():
             if result in (0, 1):
                 self.assertTrue(False, "blocking socket")
             else: break
@@ -1436,7 +1436,7 @@ class TestRecordLayer(unittest.TestCase):
 
         self.assertEqual(parser.bytes, bytearray(b'test'))
 
-    def test_recvMessage_with_encryptThenMAC_in_TLSv1_2(self):
+    def test_recvRecord_with_encryptThenMAC_in_TLSv1_2(self):
 
         # data from test_sendRecord_with_encryptThenMAC_in_TLSv1_2
         sock = MockSocket(bytearray(
@@ -1459,7 +1459,7 @@ class TestRecordLayer(unittest.TestCase):
                                       None)
         recordLayer.changeReadState()
 
-        for result in recordLayer.recvMessage():
+        for result in recordLayer.recvRecord():
             if result in (0, 1):
                 self.assertTrue(False, "blocking socket")
             else: break
@@ -1468,7 +1468,7 @@ class TestRecordLayer(unittest.TestCase):
 
         self.assertEqual(parser.bytes, bytearray(b'test'))
 
-    def test_recvMessage_with_encryptThenMAC_and_too_short_MAC(self):
+    def test_recvRecord_with_encryptThenMAC_and_too_short_MAC(self):
 
         sock = MockSocket(bytearray(
             b'\x17' +           # application data
@@ -1487,12 +1487,12 @@ class TestRecordLayer(unittest.TestCase):
                                       None)
         recordLayer.changeReadState()
 
-        gen = recordLayer.recvMessage()
+        gen = recordLayer.recvRecord()
 
         with self.assertRaises(TLSBadRecordMAC):
             next(gen)
 
-    def test_recvMessage_with_encryptThenMAC_with_modified_MAC(self):
+    def test_recvRecord_with_encryptThenMAC_with_modified_MAC(self):
 
         sock = MockSocket(bytearray(
             b'\x17' +           # application data
@@ -1514,12 +1514,12 @@ class TestRecordLayer(unittest.TestCase):
                                       None)
         recordLayer.changeReadState()
 
-        gen = recordLayer.recvMessage()
+        gen = recordLayer.recvRecord()
 
         with self.assertRaises(TLSBadRecordMAC):
             next(gen)
 
-    def test_recvMessage_with_encryptThenMAC_and_bad_size_encrypted_data(self):
+    def test_recvRecord_with_encryptThenMAC_and_bad_size_encrypted_data(self):
         # make sure the IV is predictible (all zero)
         patcher = mock.patch.object(os,
                                     'urandom',
@@ -1579,12 +1579,12 @@ class TestRecordLayer(unittest.TestCase):
                                       None)
         recordLayer.changeReadState()
 
-        gen = recordLayer.recvMessage()
+        gen = recordLayer.recvRecord()
 
         with self.assertRaises(TLSDecryptionFailed):
             next(gen)
 
-    def test_recvMessage_with_encryptThenMAC_and_bad_last_padding_byte(self):
+    def test_recvRecord_with_encryptThenMAC_and_bad_last_padding_byte(self):
         # make sure the IV is predictible (all zero)
         patcher = mock.patch.object(os,
                                     'urandom',
@@ -1652,12 +1652,12 @@ class TestRecordLayer(unittest.TestCase):
                                       None)
         recordLayer.changeReadState()
 
-        gen = recordLayer.recvMessage()
+        gen = recordLayer.recvRecord()
 
         with self.assertRaises(TLSBadRecordMAC):
             next(gen)
 
-    def test_recvMessage_with_encryptThenMAC_and_SSLv3(self):
+    def test_recvRecord_with_encryptThenMAC_and_SSLv3(self):
 
         # constructor for the data
         sendingSocket = MockSocket(bytearray())
@@ -1705,7 +1705,7 @@ class TestRecordLayer(unittest.TestCase):
                                       None)
         recordLayer.changeReadState()
 
-        for result in recordLayer.recvMessage():
+        for result in recordLayer.recvRecord():
             if result in (0, 1):
                 self.assertTrue(False, "blocking socket")
             else: break
@@ -1714,7 +1714,7 @@ class TestRecordLayer(unittest.TestCase):
 
         self.assertEqual(parser.bytes, bytearray(b'test'))
 
-    def test_recvMessage_with_encryptThenMAC_and_bad_padding_byte(self):
+    def test_recvRecord_with_encryptThenMAC_and_bad_padding_byte(self):
         # make sure the IV is predictible (all zero)
         patcher = mock.patch.object(os,
                                     'urandom',
@@ -1783,7 +1783,7 @@ class TestRecordLayer(unittest.TestCase):
                                       None)
         recordLayer.changeReadState()
 
-        gen = recordLayer.recvMessage()
+        gen = recordLayer.recvRecord()
 
         with self.assertRaises(TLSBadRecordMAC):
             next(gen)

--- a/unit_tests/test_tlslite_tlsconnection.py
+++ b/unit_tests/test_tlslite_tlsconnection.py
@@ -74,7 +74,7 @@ class TestTLSConnection(unittest.TestCase):
                 tackExt=None,
                 next_protos_advertised=None)
 
-        for res in gen_record_layer.sendMessage(server_hello):
+        for res in gen_record_layer.sendRecord(server_hello):
             if res in (0, 1):
                 self.assertTrue(False, "Blocking socket")
             else:
@@ -107,7 +107,7 @@ class TestTLSConnection(unittest.TestCase):
                                             session_id=bytearray(0),
                                             cipher_suites=ciphers)
 
-        for res in gen_record_layer.sendMessage(client_hello):
+        for res in gen_record_layer.sendRecord(client_hello):
             if res in (0, 1):
                 self.assertTrue(False, "Blocking socket")
             else:

--- a/unit_tests/test_tlslite_tlsrecordlayer.py
+++ b/unit_tests/test_tlslite_tlsrecordlayer.py
@@ -741,7 +741,7 @@ class TestTLSRecordLayer(unittest.TestCase):
 
         record_layer._changeWriteState()
 
-        handshake_hashes = record_layer._handshake_sha256.digest()
+        handshake_hashes = record_layer._handshake_hash.digest('sha256')
         verify_data = PRF_1_2(master_secret, b'client finished',
                 handshake_hashes, 12)
 
@@ -791,7 +791,7 @@ class TestTLSRecordLayer(unittest.TestCase):
 
         srv_record_layer._changeReadState()
 
-        srv_handshakeHashes = srv_record_layer._handshake_sha256.digest()
+        srv_handshakeHashes = srv_record_layer._handshake_hash.digest('sha256')
         srv_verify_data = PRF_1_2(srv_master_secret, b"client finished",
                 srv_handshakeHashes, 12)
 
@@ -813,7 +813,7 @@ class TestTLSRecordLayer(unittest.TestCase):
 
         srv_record_layer._changeWriteState()
 
-        srv_handshakeHashes = srv_record_layer._handshake_sha256.digest()
+        srv_handshakeHashes = srv_record_layer._handshake_hash.digest('sha256')
         srv_verify_data = PRF_1_2(srv_master_secret, b"server finished",
                 srv_handshakeHashes, 12)
 
@@ -841,7 +841,7 @@ class TestTLSRecordLayer(unittest.TestCase):
 
         record_layer._changeReadState()
 
-        handshake_hashes = record_layer._handshake_sha256.digest()
+        handshake_hashes = record_layer._handshake_hash.digest('sha256')
         server_verify_data = PRF_1_2(master_secret, b'server finished',
                 handshake_hashes, 12)
 
@@ -958,7 +958,7 @@ class TestTLSRecordLayer(unittest.TestCase):
 
         record_layer._changeWriteState()
 
-        handshake_hashes = record_layer._handshake_sha256.digest()
+        handshake_hashes = record_layer._handshake_hash.digest('sha256')
         verify_data = PRF_1_2(master_secret, b'client finished',
                 handshake_hashes, 12)
 
@@ -980,7 +980,7 @@ class TestTLSRecordLayer(unittest.TestCase):
 
         record_layer._changeReadState()
 
-        handshake_hashes = record_layer._handshake_sha256.digest()
+        handshake_hashes = record_layer._handshake_hash.digest('sha256')
         server_verify_data = PRF_1_2(master_secret, b'server finished',
                 handshake_hashes, 12)
 


### PR DESCRIPTION
 * add reporting of cipher name to `tls.py`
 * actually support requesting of client cert in `tls.py`
 * make optional parameters to ServerHello really optional (1st step to depreciate them)
 * trivial fixups in Makefile
 * rename `sendMessage` and `recvMessage` since they don't handle messages, just record payloads
 * implement an easier-to-work-with abstraction on top of record layer - `MessageSocket` that does automatic defragmentation and allows for bundling messages together
 * extra test coverage for recordlayer (AEAD/AES128GCM ciphers)
 * extra test coverage for TLSExtension
 * put all handshake hash updates into a single place