### PR TITLE
Extension fixes and additions

### DIFF
--- a/tlslite/constants.py
+++ b/tlslite/constants.py
@@ -44,6 +44,7 @@ class ExtensionType:    # RFC 6066 / 4366
     server_name = 0     # RFC 6066 / 4366
     cert_type = 9       # RFC 6091
     supported_groups = 10 # RFC 4492, RFC-ietf-tls-negotiated-ff-dhe-10
+    ec_point_formats = 11 # RFC 4492
     srp = 12            # RFC 5054
     encrypt_then_mac = 22 # RFC 7366
     tack = 0xF300
@@ -117,6 +118,18 @@ class GroupName(object):
     allFF = list(range(256, 261))
 
     all = allEC + allFF
+
+class ECPointFormat(object):
+
+    """Names and ID's of supported EC point formats"""
+
+    uncompressed = 0
+    ansiX962_compressed_prime = 1
+    ansiX962_compressed_char2 = 2
+
+    all = [uncompressed,
+           ansiX962_compressed_prime,
+           ansiX962_compressed_char2]
 
 class NameType:
     host_name = 0

--- a/tlslite/constants.py
+++ b/tlslite/constants.py
@@ -46,6 +46,7 @@ class ExtensionType:    # RFC 6066 / 4366
     supported_groups = 10 # RFC 4492, RFC-ietf-tls-negotiated-ff-dhe-10
     ec_point_formats = 11 # RFC 4492
     srp = 12            # RFC 5054
+    signature_algorithms = 13 # RFC 5246
     encrypt_then_mac = 22 # RFC 7366
     tack = 0xF300
     supports_npn = 13172

--- a/tlslite/constants.py
+++ b/tlslite/constants.py
@@ -42,8 +42,9 @@ class ContentType:
 
 class ExtensionType:    # RFC 6066 / 4366
     server_name = 0     # RFC 6066 / 4366
-    srp = 12            # RFC 5054  
     cert_type = 9       # RFC 6091
+    supported_groups = 10 # RFC 4492, RFC-ietf-tls-negotiated-ff-dhe-10
+    srp = 12            # RFC 5054
     encrypt_then_mac = 22 # RFC 7366
     tack = 0xF300
     supports_npn = 13172
@@ -68,6 +69,54 @@ class SignatureAlgorithm:
     rsa = 1
     dsa = 2
     ecdsa = 3
+
+class GroupName(object):
+
+    """Name of groups supported for (EC)DH key exchange"""
+
+    # RFC4492
+    sect163k1 = 1
+    sect163r1 = 2
+    sect163r2 = 3
+    sect193r1 = 4
+    sect193r2 = 5
+    sect233k1 = 6
+    sect233r1 = 7
+    sect239k1 = 8
+    sect283k1 = 9
+    sect283r1 = 10
+    sect409k1 = 11
+    sect409r1 = 12
+    sect571k1 = 13
+    sect571r1 = 14
+    secp160k1 = 15
+    secp160r1 = 16
+    secp160r2 = 17
+    secp192k1 = 18
+    secp192r1 = 19
+    secp224k1 = 20
+    secp224r1 = 21
+    secp256k1 = 22
+    secp256r1 = 23
+    secp384r1 = 24
+    secp521r1 = 25
+    allEC = list(range(1, 26))
+
+    # RFC7027
+    brainpoolP256r1 = 26
+    brainpoolP384r1 = 27
+    brainpoolP512r1 = 28
+    allEC.append(list(range(26, 29)))
+
+    # RFC-ietf-tls-negotiated-ff-dhe-10
+    ffdhe2048 = 256
+    ffdhe3072 = 257
+    ffdhe4096 = 258
+    ffdhe6144 = 259
+    ffdhe8192 = 260
+    allFF = list(range(256, 261))
+
+    all = allEC + allFF
 
 class NameType:
     host_name = 0

--- a/tlslite/constants.py
+++ b/tlslite/constants.py
@@ -50,6 +50,7 @@ class ExtensionType:    # RFC 6066 / 4366
     encrypt_then_mac = 22 # RFC 7366
     tack = 0xF300
     supports_npn = 13172
+    renegotiation_info = 0xff01
 
 class HashAlgorithm:
 

--- a/tlslite/extensions.py
+++ b/tlslite/extensions.py
@@ -350,8 +350,8 @@ class SNIExtension(TLSExtension):
         return w.bytes
 
     def parse(self, p):
-        """ Parses the on the wire extension data and returns an object that
-        represents it.
+        """
+        Deserialise the extension from on-the-wire data
 
         The parser should not include the type or length of extension!
 
@@ -362,6 +362,9 @@ class SNIExtension(TLSExtension):
         @raise SyntaxError: when the internal sizes don't match the attached
             data
         """
+        if p.getRemainingLength() == 0:
+            return self
+
         self.server_names = []
 
         p.startLengthCheck(2)

--- a/tlslite/extensions.py
+++ b/tlslite/extensions.py
@@ -1118,7 +1118,8 @@ class SignatureAlgorithmsExtension(TLSExtension):
 
         return self
 
-TLSExtension._universal_extensions = {
+TLSExtension._universal_extensions = \
+    {
         ExtensionType.server_name : SNIExtension,
         ExtensionType.cert_type : ClientCertTypeExtension,
         ExtensionType.supported_groups : SupportedGroupsExtension,
@@ -1127,6 +1128,7 @@ TLSExtension._universal_extensions = {
         ExtensionType.signature_algorithms : SignatureAlgorithmsExtension,
         ExtensionType.supports_npn : NPNExtension}
 
-TLSExtension._server_extensions = {
+TLSExtension._server_extensions = \
+    {
         ExtensionType.cert_type : ServerCertTypeExtension,
         ExtensionType.tack : TACKExtension}

--- a/tlslite/messages.py
+++ b/tlslite/messages.py
@@ -909,12 +909,7 @@ class CertificateRequest(HandshakeMsg):
         w = Writer()
         w.addVarSeq(self.certificate_types, 1, 1)
         if self.version >= (3,3):
-            w2 = Writer()
-            for (hash_alg, signature) in self.supported_signature_algs:
-                w2.add(hash_alg, 1)
-                w2.add(signature, 1)
-            w.add(len(w2.bytes), 2)
-            w.bytes += w2.bytes
+            w.addVarTupleSeq(self.supported_signature_algs, 1, 2)
         caLength = 0
         #determine length
         for ca_dn in self.certificate_authorities:

--- a/tlslite/tlsconnection.py
+++ b/tlslite/tlsconnection.py
@@ -152,9 +152,9 @@ class TLSConnection(TLSRecordLayer):
     # Client Handshake Functions
     #*********************************************************
 
-    def handshakeClientAnonymous(self, session=None, settings=None, 
-                                checker=None, serverName="",
-                                async=False):
+    def handshakeClientAnonymous(self, session=None, settings=None,
+                                 checker=None, serverName=None,
+                                 async=False):
         """Perform an anonymous handshake in the role of client.
 
         This function performs an SSL or TLS handshake using an
@@ -218,8 +218,8 @@ class TLSConnection(TLSRecordLayer):
             pass
 
     def handshakeClientSRP(self, username, password, session=None,
-                           settings=None, checker=None, 
-                           reqTack=True, serverName="",
+                           settings=None, checker=None,
+                           reqTack=True, serverName=None,
                            async=False):
         """Perform an SRP handshake in the role of client.
 
@@ -301,7 +301,7 @@ class TLSConnection(TLSRecordLayer):
 
     def handshakeClientCert(self, certChain=None, privateKey=None,
                             session=None, settings=None, checker=None,
-                            nextProtos=None, reqTack=True, serverName="",
+                            nextProtos=None, reqTack=True, serverName=None,
                             async=False):
         """Perform a certificate-based handshake in the role of client.
 
@@ -378,10 +378,13 @@ class TLSConnection(TLSRecordLayer):
         @raise tlslite.errors.TLSAuthenticationError: If the checker
         doesn't like the other party's authentication credentials.
         """
-        handshaker = self._handshakeClientAsync(certParams=(certChain,
-                        privateKey), session=session, settings=settings,
-                        checker=checker, serverName=serverName, 
-                        nextProtos=nextProtos, reqTack=reqTack)
+        handshaker = \
+                self._handshakeClientAsync(certParams=(certChain, privateKey),
+                                           session=session, settings=settings,
+                                           checker=checker,
+                                           serverName=serverName,
+                                           nextProtos=nextProtos,
+                                           reqTack=reqTack)
         # The handshaker is a Python Generator which executes the handshake.
         # It allows the handshake to be run in a "piecewise", asynchronous
         # fashion, returning 1 when it is waiting to able to write, 0 when
@@ -396,8 +399,8 @@ class TLSConnection(TLSRecordLayer):
 
 
     def _handshakeClientAsync(self, srpParams=(), certParams=(), anonParams=(),
-                             session=None, settings=None, checker=None,
-                             nextProtos=None, serverName="", reqTack=True):
+                              session=None, settings=None, checker=None,
+                              nextProtos=None, serverName=None, reqTack=True):
 
         handshaker = self._handshakeClientAsyncHelper(srpParams=srpParams,
                 certParams=certParams,

--- a/tlslite/utils/codec.py
+++ b/tlslite/utils/codec.py
@@ -28,6 +28,35 @@ class Writer(object):
         for e in seq:
             self.add(e, length)
 
+    def addVarTupleSeq(self, seq, length, lengthLength):
+        """
+        Add a variable length list of same-sized element tuples.
+
+        Note that all tuples must have the same size.
+
+        Inverse of Parser.getVarTupleList()
+
+        @type seq: enumerable
+        @param seq: list of tuples
+
+        @type length: int
+        @param length: length of single element in tuple
+
+        @type lengthLength: int
+        @param lengthLength: length in bytes of overall length field
+        """
+        if len(seq) == 0:
+            self.add(0, lengthLength)
+        else:
+            tupleSize = len(seq[0])
+            tupleLength = tupleSize*length
+            self.add(len(seq)*tupleLength, lengthLength)
+            for elemTuple in seq:
+                if len(elemTuple) != tupleSize:
+                    raise ValueError("Tuples of different sizes")
+                for elem in elemTuple:
+                    self.add(elem, length)
+
 class Parser(object):
     def __init__(self, bytes):
         self.bytes = bytes

--- a/unit_tests/test_tlslite_extensions.py
+++ b/unit_tests/test_tlslite_extensions.py
@@ -122,7 +122,7 @@ class TestTLSExtension(unittest.TestCase):
         ext = TLSExtension(server=True).parse(p)
 
         self.assertIsInstance(ext, SNIExtension)
-        self.assertEqual(ext.server_names, None)
+        self.assertIsNone(ext.server_names)
 
     def test_parse_with_renego_info_server_side(self):
         p = Parser(bytearray(
@@ -286,7 +286,7 @@ class TestSNIExtension(unittest.TestCase):
     def test___init__(self):
         server_name = SNIExtension()
 
-        self.assertEqual(None, server_name.server_names)
+        self.assertIsNone(server_name.server_names)
         self.assertEqual(tuple(), server_name.host_names)
         # properties inherited from TLSExtension:
         self.assertEqual(0, server_name.ext_type)
@@ -296,7 +296,7 @@ class TestSNIExtension(unittest.TestCase):
         server_name = SNIExtension()
         server_name = server_name.create()
 
-        self.assertEqual(None, server_name.server_names)
+        self.assertIsNone(server_name.server_names)
         self.assertEqual(tuple(), server_name.host_names)
 
     def test_create_with_hostname(self):
@@ -633,7 +633,7 @@ class TestClientCertTypeExtension(unittest.TestCase):
 
         self.assertEqual(9, cert_type.ext_type)
         self.assertEqual(bytearray(0), cert_type.ext_data)
-        self.assertEqual(None, cert_type.cert_types)
+        self.assertIsNone(cert_type.cert_types)
 
     def test_create(self):
         cert_type = ClientCertTypeExtension()
@@ -641,7 +641,7 @@ class TestClientCertTypeExtension(unittest.TestCase):
 
         self.assertEqual(9, cert_type.ext_type)
         self.assertEqual(bytearray(0), cert_type.ext_data)
-        self.assertEqual(None, cert_type.cert_types)
+        self.assertIsNone(cert_type.cert_types)
 
     def test_create_with_empty_list(self):
         cert_type = ClientCertTypeExtension()
@@ -707,7 +707,7 @@ class TestServerCertTypeExtension(unittest.TestCase):
 
         self.assertEqual(9, cert_type.ext_type)
         self.assertEqual(bytearray(0), cert_type.ext_data)
-        self.assertEqual(None, cert_type.cert_type)
+        self.assertIsNone(cert_type.cert_type)
 
     def test_create(self):
         cert_type = ServerCertTypeExtension().create(0)
@@ -760,7 +760,7 @@ class TestSRPExtension(unittest.TestCase):
     def test___init___(self):
         srp_extension = SRPExtension()
 
-        self.assertEqual(None, srp_extension.identity)
+        self.assertIsNone(srp_extension.identity)
         self.assertEqual(12, srp_extension.ext_type)
         self.assertEqual(bytearray(0), srp_extension.ext_data)
 
@@ -768,7 +768,7 @@ class TestSRPExtension(unittest.TestCase):
         srp_extension = SRPExtension()
         srp_extension = srp_extension.create()
 
-        self.assertEqual(None, srp_extension.identity)
+        self.assertIsNone(srp_extension.identity)
         self.assertEqual(12, srp_extension.ext_type)
         self.assertEqual(bytearray(0), srp_extension.ext_data)
 
@@ -836,7 +836,7 @@ class TestNPNExtension(unittest.TestCase):
     def test___init___(self):
         npn_extension = NPNExtension()
 
-        self.assertEqual(None, npn_extension.protocols)
+        self.assertIsNone(npn_extension.protocols)
         self.assertEqual(13172, npn_extension.ext_type)
         self.assertEqual(bytearray(0), npn_extension.ext_data)
 
@@ -844,7 +844,7 @@ class TestNPNExtension(unittest.TestCase):
         npn_extension = NPNExtension()
         npn_extension = npn_extension.create()
 
-        self.assertEqual(None, npn_extension.protocols)
+        self.assertIsNone(npn_extension.protocols)
         self.assertEqual(13172, npn_extension.ext_type)
         self.assertEqual(bytearray(0), npn_extension.ext_data)
 

--- a/unit_tests/test_tlslite_extensions.py
+++ b/unit_tests/test_tlslite_extensions.py
@@ -111,6 +111,18 @@ class TestTLSExtension(unittest.TestCase):
 
         self.assertEqual(ext.protocols, [b'http/1.1'])
 
+    def test_parse_with_renego_info_server_side(self):
+        p = Parser(bytearray(
+            b'\xff\x01' +   # type of extension - renegotiation_info
+            b'\x00\x01' +   # overall length
+            b'\x00'         # extension length
+            ))
+
+        ext = TLSExtension(server=True).parse(p)
+
+        # XXX not supported
+        self.assertIsInstance(ext, TLSExtension)
+
     def test_parse_with_elliptic_curves(self):
         p = Parser(bytearray(
             b'\x00\x0a' +   # type of extension

--- a/unit_tests/test_tlslite_extensions.py
+++ b/unit_tests/test_tlslite_extensions.py
@@ -111,6 +111,17 @@ class TestTLSExtension(unittest.TestCase):
 
         self.assertEqual(ext.protocols, [b'http/1.1'])
 
+    def test_parse_with_SNI_server_side(self):
+        p = Parser(bytearray(
+            b'\x00\x00' +   # type of extension - SNI
+            b'\x00\x00'     # overall length - 0 bytes
+            ))
+
+        ext = TLSExtension(server=True).parse(p)
+
+        self.assertIsInstance(ext, SNIExtension)
+        self.assertEqual(ext.server_names, None)
+
     def test_parse_with_renego_info_server_side(self):
         p = Parser(bytearray(
             b'\xff\x01' +   # type of extension - renegotiation_info
@@ -414,13 +425,22 @@ class TestSNIExtension(unittest.TestCase):
             b'\x00\x00'    # length of array of names - 0 bytes
             ), server_name.write())
 
-    def test_parse(self):
+    def tes_parse_with_invalid_data(self):
+        server_name = SNIExtension()
+
+        p = Parser(bytearray(b'\x00\x01'))
+
+        with self.assertRaises(SyntaxError):
+            server_name.parse(p)
+
+    def test_parse_of_server_side_version(self):
         server_name = SNIExtension()
 
         p = Parser(bytearray(0))
 
-        with self.assertRaises(SyntaxError):
-            server_name = server_name.parse(p)
+        server_name = server_name.parse(p)
+
+        self.assertIsNone(server_name.server_names)
 
     def test_parse_null_length_array(self):
         server_name = SNIExtension()

--- a/unit_tests/test_tlslite_extensions.py
+++ b/unit_tests/test_tlslite_extensions.py
@@ -136,6 +136,9 @@ class TestTLSExtension(unittest.TestCase):
         # XXX not supported
         self.assertIsInstance(ext, TLSExtension)
 
+        self.assertEqual(ext.ext_data, bytearray(b'\x00'))
+        self.assertEqual(ext.ext_type, 0xff01)
+
     def test_parse_with_elliptic_curves(self):
         p = Parser(bytearray(
             b'\x00\x0a' +   # type of extension

--- a/unit_tests/test_tlslite_extensions.py
+++ b/unit_tests/test_tlslite_extensions.py
@@ -11,7 +11,7 @@ except ImportError:
 from tlslite.extensions import TLSExtension, SNIExtension, NPNExtension,\
         SRPExtension, ClientCertTypeExtension, ServerCertTypeExtension,\
         TACKExtension, SupportedGroupsExtension, ECPointFormatsExtension,\
-        SupportedGroupsExtension, SignatureAlgorithmsExtension
+        SignatureAlgorithmsExtension
 from tlslite.utils.codec import Parser
 from tlslite.constants import NameType, ExtensionType, GroupName,\
         ECPointFormat, HashAlgorithm, SignatureAlgorithm

--- a/unit_tests/test_tlslite_utils_codec.py
+++ b/unit_tests/test_tlslite_utils_codec.py
@@ -251,5 +251,37 @@ class TestWriter(unittest.TestCase):
 
         self.assertEqual(bytearray(b'\xbe\xef\x0f'), w.bytes)
 
+    def test_addVarTupleSeq(self):
+        w = Writer()
+        w.addVarTupleSeq([(1, 2), (2, 9)], 1, 2)
+
+        self.assertEqual(bytearray(
+            b'\x00\x04' + # length
+            b'\x01\x02' + # first tuple
+            b'\x02\x09'   # second tuple
+            ), w.bytes)
+
+    def test_addVarTupleSeq_with_single_element_tuples(self):
+        w = Writer()
+        w.addVarTupleSeq([[1], [9], [12]], 2, 3)
+
+        self.assertEqual(bytearray(
+            b'\x00\x00\x06' + # length
+            b'\x00\x01' + # 1st element
+            b'\x00\x09' + # 2nd element
+            b'\x00\x0c'), w.bytes)
+
+    def test_addVarTupleSeq_with_empty_array(self):
+        w = Writer()
+        w.addVarTupleSeq([], 1, 2)
+
+        self.assertEqual(bytearray(
+            b'\x00\x00'), w.bytes)
+
+    def test_addVarTupleSeq_with_invalid_sized_tuples(self):
+        w = Writer()
+        with self.assertRaises(ValueError):
+            w.addVarTupleSeq([(1, 2), (2, 3, 9)], 1, 2)
+
 if __name__ == '__main__':
     unittest.main()


### PR DESCRIPTION
 - don't send empty SNI extension if no name specified
 - fix parsing of server side reply to server_name extension
 - add supported_groups, supported_point_formats, signature_algorithms and renegotiation_info extensions
 - more test coverage