### PR TITLE
fix CVE-2015-3220

### DIFF
--- a/tlslite/recordlayer.py
+++ b/tlslite/recordlayer.py
@@ -530,6 +530,9 @@ class RecordLayer(object):
             if self.version >= (3, 2):
                 buf = buf[blockLength:]
 
+            if len(buf) == 0:
+                raise TLSBadRecordMAC("No data left after IV removal")
+
             # check padding
             paddingLength = buf[-1]
             if paddingLength + 1 > len(buf):


### PR DESCRIPTION
adds test cases for "no pad length byte"

since the MAC-then-Encrypt code was rewritten to fix Lucky 13
it wasn't vulnerable, only the Encrypt-then-MAC remained vulnerable,
this fixes this issue