### PR TITLE
Fix issue where Encrypt-then-MAC was technically negotiated with AEAD ciphersuites

### DIFF
--- a/tests/tlstest.py
+++ b/tests/tlstest.py
@@ -117,7 +117,8 @@ def clientTestCmd(argv):
     testConnClient(connection)
     assert(isinstance(connection.session.serverCertChain, X509CertChain))
     assert(connection.session.serverName == address[0])
-    assert(connection.encryptThenMAC == True)
+    assert(connection.session.cipherSuite in constants.CipherSuite.aeadSuites)
+    assert(connection.encryptThenMAC == False)
     connection.close()
 
     print("Test 1.a - good X509, SSLv3")
@@ -141,6 +142,7 @@ def clientTestCmd(argv):
     testConnClient(connection)    
     assert(isinstance(connection.session.serverCertChain, X509CertChain))
     assert(connection.session.cipherSuite == constants.CipherSuite.TLS_RSA_WITH_RC4_128_MD5)
+    assert(connection.encryptThenMAC == False)
     connection.close()
 
     if tackpyLoaded:
@@ -471,6 +473,7 @@ def clientTestCmd(argv):
     synchro.recv(1)
     connection = connect()
     settings = HandshakeSettings()
+    settings.macNames.remove("aead")
     assert(settings.useEncryptThenMAC)
     connection.handshakeClientCert(serverName=address[0], settings=settings)
     testConnClient(connection)
@@ -483,6 +486,7 @@ def clientTestCmd(argv):
     synchro.recv(1)
     connection = connect()
     settings = HandshakeSettings()
+    settings.macNames.remove("aead")
     settings.useEncryptThenMAC = False
     connection.handshakeClientCert(serverName=address[0], settings=settings)
     testConnClient(connection)
@@ -494,7 +498,9 @@ def clientTestCmd(argv):
     print("Test 26.c - resumption with EtM")
     synchro.recv(1)
     connection = connect()
-    connection.handshakeClientCert(serverName=address[0])
+    settings = HandshakeSettings()
+    settings.macNames.remove("aead")
+    connection.handshakeClientCert(serverName=address[0], settings=settings)
     testConnClient(connection)
     assert(isinstance(connection.session.serverCertChain, X509CertChain))
     assert(connection.session.serverName == address[0])
@@ -517,7 +523,9 @@ def clientTestCmd(argv):
     print("Test 26.d - resumption with no EtM in 2nd handshake")
     synchro.recv(1)
     connection = connect()
-    connection.handshakeClientCert(serverName=address[0])
+    settings = HandshakeSettings()
+    settings.macNames.remove("aead")
+    connection.handshakeClientCert(serverName=address[0], settings=settings)
     testConnClient(connection)
     assert(isinstance(connection.session.serverCertChain, X509CertChain))
     assert(connection.session.serverName == address[0])
@@ -530,6 +538,7 @@ def clientTestCmd(argv):
     synchro.recv(1)
     settings = HandshakeSettings()
     settings.useEncryptThenMAC = False
+    settings.macNames.remove("aead")
     connection = connect()
     try:
         connection.handshakeClientCert(serverName=address[0], session=session,

--- a/tlslite/constants.py
+++ b/tlslite/constants.py
@@ -413,14 +413,17 @@ class CipherSuite:
     sha256Suites.append(TLS_RSA_WITH_AES_256_CBC_SHA256)
     sha256Suites.append(TLS_DHE_RSA_WITH_AES_128_CBC_SHA256)
     sha256Suites.append(TLS_DHE_RSA_WITH_AES_256_CBC_SHA256)
-    sha256Suites.append(TLS_RSA_WITH_AES_128_GCM_SHA256)
-    sha256Suites.append(TLS_DHE_RSA_WITH_AES_128_GCM_SHA256)
     sha256Suites.append(TLS_RSA_WITH_NULL_SHA256)
     sha256Suites.append(TLS_DH_ANON_WITH_AES_128_CBC_SHA256)
     sha256Suites.append(TLS_DH_ANON_WITH_AES_256_CBC_SHA256)
 
     # SHA-384 HMAC, SHA-384 PRF
     sha384Suites = []
+
+    # stream cipher construction
+    streamSuites = []
+    streamSuites.extend(rc4Suites)
+    streamSuites.extend(nullSuites)
 
     # AEAD integrity, any PRF
     aeadSuites = []

--- a/tlslite/handshakesettings.py
+++ b/tlslite/handshakesettings.py
@@ -102,13 +102,13 @@ class HandshakeSettings(object):
     def __init__(self):
         self.minKeySize = 1023
         self.maxKeySize = 8193
-        self.cipherNames = CIPHER_NAMES
-        self.macNames = MAC_NAMES
-        self.keyExchangeNames = KEY_EXCHANGE_NAMES
-        self.cipherImplementations = CIPHER_IMPLEMENTATIONS
-        self.certificateTypes = CERTIFICATE_TYPES
-        self.minVersion = (3,1)
-        self.maxVersion = (3,3)
+        self.cipherNames = list(CIPHER_NAMES)
+        self.macNames = list(MAC_NAMES)
+        self.keyExchangeNames = list(KEY_EXCHANGE_NAMES)
+        self.cipherImplementations = list(CIPHER_IMPLEMENTATIONS)
+        self.certificateTypes = list(CERTIFICATE_TYPES)
+        self.minVersion = (3, 1)
+        self.maxVersion = (3, 3)
         self.useExperimentalTackExtension = False
         self.sendFallbackSCSV = False
         self.useEncryptThenMAC = True

--- a/tlslite/tlsconnection.py
+++ b/tlslite/tlsconnection.py
@@ -1418,7 +1418,8 @@ class TLSConnection(TLSRecordLayer):
         # Prepare other extensions if requested
         if settings.useEncryptThenMAC and \
                 clientHello.getExtension(ExtensionType.encrypt_then_mac) and \
-                cipherSuite not in CipherSuite.rc4Suites:
+                cipherSuite not in CipherSuite.streamSuites and \
+                cipherSuite not in CipherSuite.aeadSuites:
             extensions = [TLSExtension().create(ExtensionType.encrypt_then_mac,
                                                 bytearray(0))]
             self._recordLayer.encryptThenMAC = True


### PR DESCRIPTION
Because tlslite-ng did filter out only RC4 ciphers when checking for EtM, this meant that it looked like EtM was negotiated for AEAD and NULL ciphers too.

this patch set resolves this issue