### PR TITLE
fix python3.2 builds

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -73,6 +73,7 @@ install:
   - if [[ $M2CRYPTO == 'true' ]]; then travis_retry pip install M2Crypto; fi
   - if [[ $PYCRYPTO == 'true' ]]; then travis_retry pip install pycrypto; fi
   - if [[ $GMPY == 'true' ]]; then travis_retry pip install gmpy; fi
+  - if [[ $TRAVIS_PYTHON_VERSION == '3.2' ]]; then travis_retry pip install 'coverage<4'; else travis_retry pip install coverage; fi
   - travis_retry pip install -r build-requirements.txt
 
 script:

--- a/build-requirements.txt
+++ b/build-requirements.txt
@@ -1,4 +1,3 @@
 pylint
 diff_cover
-coverage
 coveralls


### PR DESCRIPTION
because coverage 4.0 is officially incompatible with
Python 3.2, we must install older version of it when
running on Python 3.2