### PR TITLE
Expose some record layer private methods

### DIFF
--- a/tlslite/recordlayer.py
+++ b/tlslite/recordlayer.py
@@ -297,7 +297,7 @@ class RecordLayer(object):
     # sending messages
     #
 
-    def _addPadding(self, data):
+    def addPadding(self, data):
         """Add padding to data so that it is multiple of block size"""
         currentLength = len(data)
         blockLength = self._writeState.encContext.block_size
@@ -337,7 +337,7 @@ class RecordLayer(object):
                 if self.version >= (3, 2):
                     data = self.fixedIVBlock + data
 
-                data = self._addPadding(data)
+                data = self.addPadding(data)
 
             #Encrypt
             data = self._writeState.encContext.encrypt(data)
@@ -351,7 +351,7 @@ class RecordLayer(object):
             if self.version >= (3, 2):
                 buf = self.fixedIVBlock + buf
 
-            buf = self._addPadding(buf)
+            buf = self.addPadding(buf)
 
             buf = self._writeState.encContext.encrypt(buf)
 

--- a/tlslite/recordlayer.py
+++ b/tlslite/recordlayer.py
@@ -307,7 +307,7 @@ class RecordLayer(object):
         data += paddingBytes
         return data
 
-    def _calculateMAC(self, mac, seqnumBytes, contentType, data):
+    def calculateMAC(self, mac, seqnumBytes, contentType, data):
         """Calculate the SSL/TLS version of a MAC"""
         mac.update(compatHMAC(seqnumBytes))
         mac.update(compatHMAC(bytearray([contentType])))
@@ -325,7 +325,7 @@ class RecordLayer(object):
         if self._writeState.macContext:
             seqnumBytes = self._writeState.getSeqNumBytes()
             mac = self._writeState.macContext.copy()
-            macBytes = self._calculateMAC(mac, seqnumBytes, contentType, data)
+            macBytes = self.calculateMAC(mac, seqnumBytes, contentType, data)
             data += macBytes
 
         #Encrypt for Block or Stream Cipher
@@ -361,7 +361,7 @@ class RecordLayer(object):
             mac = self._writeState.macContext.copy()
 
             # append MAC
-            macBytes = self._calculateMAC(mac, seqnumBytes, contentType, buf)
+            macBytes = self.calculateMAC(mac, seqnumBytes, contentType, buf)
             buf += macBytes
 
         return buf
@@ -443,8 +443,8 @@ class RecordLayer(object):
                 seqnumBytes = self._readState.getSeqNumBytes()
                 data = data[:-endLength]
                 mac = self._readState.macContext.copy()
-                macBytes = self._calculateMAC(mac, seqnumBytes, recordType,
-                                              data)
+                macBytes = self.calculateMAC(mac, seqnumBytes, recordType,
+                                             data)
 
                 #Compare MACs
                 if not ct_compare_digest(macBytes, checkBytes):
@@ -513,7 +513,7 @@ class RecordLayer(object):
             seqnumBytes = self._readState.getSeqNumBytes()
             mac = self._readState.macContext.copy()
 
-            macBytes = self._calculateMAC(mac, seqnumBytes, recordType, buf)
+            macBytes = self.calculateMAC(mac, seqnumBytes, recordType, buf)
 
             if not ct_compare_digest(macBytes, checkBytes):
                 raise TLSBadRecordMAC("MAC mismatch")

--- a/unit_tests/test_tlslite_recordlayer.py
+++ b/unit_tests/test_tlslite_recordlayer.py
@@ -1327,7 +1327,7 @@ class TestRecordLayer(unittest.TestCase):
                            bytearray([paddingLength])
             data += paddingBytes
             return data
-        sendingRecordLayer._addPadding = broken_padding
+        sendingRecordLayer.addPadding = broken_padding
 
         msg = ApplicationData().create(bytearray(b'test'))
 
@@ -1405,7 +1405,7 @@ class TestRecordLayer(unittest.TestCase):
                            bytearray([255])
             data += paddingBytes
             return data
-        sendingRecordLayer._addPadding = broken_padding
+        sendingRecordLayer.addPadding = broken_padding
 
         msg = ApplicationData().create(bytearray(b'test'))
 
@@ -1477,7 +1477,7 @@ class TestRecordLayer(unittest.TestCase):
                            bytearray([paddingLength])
             data += paddingBytes
             return data
-        sendingRecordLayer._addPadding = broken_padding
+        sendingRecordLayer.addPadding = broken_padding
 
         msg = ApplicationData().create(bytearray(b'test'))
 
@@ -1548,7 +1548,7 @@ class TestRecordLayer(unittest.TestCase):
                            bytearray([paddingLength])
             data += paddingBytes
             return data
-        sendingRecordLayer._addPadding = broken_padding
+        sendingRecordLayer.addPadding = broken_padding
 
         msg = ApplicationData().create(bytearray(b'test'))
 
@@ -1619,7 +1619,7 @@ class TestRecordLayer(unittest.TestCase):
                            bytearray([paddingLength])
             data += paddingBytes
             return data
-        sendingRecordLayer._addPadding = broken_padding
+        sendingRecordLayer.addPadding = broken_padding
 
         msg = ApplicationData().create(bytearray(b'test'))
 
@@ -1890,7 +1890,7 @@ class TestRecordLayer(unittest.TestCase):
                            bytearray([255])
             data += paddingBytes
             return data
-        sendingRecordLayer._addPadding = broken_padding
+        sendingRecordLayer.addPadding = broken_padding
 
         msg = ApplicationData().create(bytearray(b'test'))
 
@@ -2021,7 +2021,7 @@ class TestRecordLayer(unittest.TestCase):
                            bytearray([paddingLength])
             data += paddingBytes
             return data
-        sendingRecordLayer._addPadding = broken_padding
+        sendingRecordLayer.addPadding = broken_padding
 
         msg = ApplicationData().create(bytearray(b'test'))
 

--- a/unit_tests/test_tlslite_utils_constanttime.py
+++ b/unit_tests/test_tlslite_utils_constanttime.py
@@ -107,8 +107,8 @@ class TestContanttimeCBCCheck(unittest.TestCase):
 
         h = hmac.new(key, digestmod=mac)
 
-        digest = r_layer._calculateMAC(h, seqnum_bytes, content_type,
-                                       application_data)
+        digest = r_layer.calculateMAC(h, seqnum_bytes, content_type,
+                                      application_data)
 
         return application_data + digest
 


### PR DESCRIPTION
To make unit testing a bit cleaner and make a API promise for `tlsfuzzer`, expose the key private methods for handling MAC values and padding in CBC ciphers.