### PR TITLE
pep257 configuration

### DIFF
--- a/.landscape.yaml
+++ b/.landscape.yaml
@@ -10,3 +10,7 @@ ignore-paths:
     - tests
     - unit_tests
     - scripts
+
+pep257:
+    disable:
+        - D203

--- a/.pep257
+++ b/.pep257
@@ -1,0 +1,3 @@
+[pep257]
+
+add-ignore = D203


### PR DESCRIPTION
both when running standalone and when running as part
of prospector tool

We ignore D203 because it conflicts with the newer D211,
the former requires 1 whiteline before class doc text while
the latter requires no whitelines before class doc text