### PR TITLE
Extensions deduplication

### DIFF
--- a/pylintrc
+++ b/pylintrc
@@ -198,7 +198,7 @@ module-name-hint=(([a-z_][a-z0-9_]*)|([A-Z][a-zA-Z0-9]+))$
 # Regular expression matching correct method names
 #method-rgx=[a-z_][a-z0-9_]{2,30}$
 # mixedCase
-method-rgx=_?[a-z][A-Za-z0-9]{1,30}$
+method-rgx=((_?[a-z][A-Za-z0-9]{1,30})|(__.*__))$
 
 # Naming hint for method names
 method-name-hint=[a-z_][a-z0-9_]{2,30}$

--- a/tlslite/extensions.py
+++ b/tlslite/extensions.py
@@ -973,12 +973,8 @@ class SupportedGroupsExtension(TLSExtension):
         if parser.getRemainingLength() == 0:
             self.groups = None
             return self
-        self.groups = []
 
-        parser.startLengthCheck(2)
-        while not parser.atLengthCheck():
-            self.groups.append(parser.get(2))
-        parser.stopLengthCheck()
+        self.groups = parser.getVarList(2, 2)
 
         return self
 
@@ -1041,12 +1037,7 @@ class ECPointFormatsExtension(TLSExtension):
             self.formats = None
             return self
 
-        self.formats = []
-
-        parser.startLengthCheck(1)
-        while not parser.atLengthCheck():
-            self.formats.append(parser.get(1))
-        parser.stopLengthCheck()
+        self.formats = parser.getVarList(1, 1)
 
         return self
 

--- a/tlslite/extensions.py
+++ b/tlslite/extensions.py
@@ -429,12 +429,9 @@ class ClientCertTypeExtension(TLSExtension):
         if self.certTypes is None:
             return bytearray(0)
 
-        w = Writer()
-        w.add(len(self.certTypes), 1)
-        for c_type in self.certTypes:
-            w.add(c_type, 1)
-
-        return w.bytes
+        writer = Writer()
+        writer.addVarSeq(self.certTypes, 1, 1)
+        return writer.bytes
 
     def create(self, certTypes=None):
         """
@@ -947,10 +944,7 @@ class SupportedGroupsExtension(TLSExtension):
             return bytearray(0)
 
         writer = Writer()
-        # encode length of two bytes per group in two bytes
-        writer.add(len(self.groups) * 2, 2)
-        for group in self.groups:
-            writer.add(group, 2)
+        writer.addVarSeq(self.groups, 2, 2)
         return writer.bytes
 
     def create(self, groups):
@@ -1010,10 +1004,7 @@ class ECPointFormatsExtension(TLSExtension):
             return bytearray(0)
 
         writer = Writer()
-        # the length is number of formats encoded in one byte
-        writer.add(len(self.formats), 1)
-        for fmt in self.formats:
-            writer.add(fmt, 1)
+        writer.addVarSeq(self.formats, 1, 1)
         return writer.bytes
 
     def create(self, formats):

--- a/tlslite/extensions.py
+++ b/tlslite/extensions.py
@@ -122,23 +122,23 @@ class TLSExtension(object):
         """
 
         extType = p.get(2)
-        ext_length = p.get(2)
+        extLength = p.get(2)
 
         # first check if we shouldn't use server side parser
         if self.serverType and extType in self._serverExtensions:
-            return self._parseExt(p, extType, ext_length,
+            return self._parseExt(p, extType, extLength,
                                   self._serverExtensions)
 
         # then fallback to universal/ClientHello-specific parsers
         if extType in self._universalExtensions:
-            return self._parseExt(p, extType, ext_length,
+            return self._parseExt(p, extType, extLength,
                                   self._universalExtensions)
 
         # finally, just save the extension data as there are extensions which
         # don't require specific handlers and indicate option by mere presence
         self.extType = extType
-        self.extData = p.getFixBytes(ext_length)
-        assert len(self.extData) == ext_length
+        self.extData = p.getFixBytes(extLength)
+        assert len(self.extData) == extLength
         return self
 
     def __eq__(self, that):

--- a/tlslite/extensions.py
+++ b/tlslite/extensions.py
@@ -320,6 +320,7 @@ class SNIExtension(TLSExtension):
 
         See also: L{create} and L{parse}.
         """
+        super(SNIExtension, self).__init__(extType=ExtensionType.server_name)
         self.serverNames = None
 
     def __repr__(self):
@@ -373,14 +374,6 @@ class SNIExtension(TLSExtension):
             self.serverNames += serverNames
 
         return self
-
-    @property
-    def extType(self):
-        """ Return the type of TLS extension, in this case - 0
-
-        @rtype: int
-        """
-        return ExtensionType.server_name
 
     @property
     def hostNames(self):
@@ -518,7 +511,7 @@ class ServerCertTypeExtension(TLSExtension):
     defined in RFC 6091.
 
     @type extType: int
-    @ivar extType: byneruc ttoe if Certificate Type extension, i.e. 9
+    @ivar extType: binary type of Certificate Type extension, i.e. 9
 
     @type extData: bytearray
     @ivar extData: raw representation of the extension data
@@ -533,7 +526,8 @@ class ServerCertTypeExtension(TLSExtension):
 
         See also: L{create} and L{parse}
         """
-
+        super(ServerCertTypeExtension, self).__init__(server=True, \
+                                               extType=ExtensionType.cert_type)
         self.cert_type = None
 
     def __repr__(self):
@@ -542,15 +536,6 @@ class ServerCertTypeExtension(TLSExtension):
         @rtype: str
         """
         return "ServerCertTypeExtension(cert_type={0!r})".format(self.cert_type)
-
-    @property
-    def extType(self):
-        """
-        Return the type of TLS extension, in this case - 9
-
-        @rtype: int
-        """
-        return ExtensionType.cert_type
 
     @property
     def extData(self):
@@ -609,6 +594,7 @@ class SRPExtension(TLSExtension):
 
         See also: L{create} and L{parse}
         """
+        super(SRPExtension, self).__init__(extType=ExtensionType.srp)
 
         self.identity = None
 
@@ -619,16 +605,6 @@ class SRPExtension(TLSExtension):
         @rtype: str
         """
         return "SRPExtension(identity={0!r})".format(self.identity)
-
-    @property
-    def extType(self):
-        """
-        Return the type of TLS extension, in this case - 12
-
-        @rtype: int
-        """
-
-        return ExtensionType.srp
 
     @property
     def extData(self):
@@ -702,6 +678,7 @@ class NPNExtension(TLSExtension):
 
         See also: L{create} and L{parse}
         """
+        super(NPNExtension, self).__init__(extType=ExtensionType.supports_npn)
 
         self.protocols = None
 
@@ -712,14 +689,6 @@ class NPNExtension(TLSExtension):
         @rtype: str
         """
         return "NPNExtension(protocols={0!r})".format(self.protocols)
-
-    @property
-    def extType(self):
-        """ Return the type of TLS extension, in this case - 13172
-
-        @rtype: int
-        """
-        return ExtensionType.supports_npn
 
     @property
     def extData(self):
@@ -888,6 +857,7 @@ class TACKExtension(TLSExtension):
 
         See also: L{create} and L{parse}
         """
+        super(TACKExtension, self).__init__(extType=ExtensionType.tack)
 
         self.tacks = []
         self.activation_flags = 0
@@ -900,15 +870,6 @@ class TACKExtension(TLSExtension):
         """
         return "TACKExtension(activation_flags={0!r}, tacks={1!r})".format(
                 self.activation_flags, self.tacks)
-
-    @property
-    def extType(self):
-        """
-        Returns the type of TLS extension, in this case - 62208
-
-        @rtype: int
-        """
-        return ExtensionType.tack
 
     @property
     def extData(self):
@@ -1001,16 +962,10 @@ class SignatureAlgorithmsExtension(TLSExtension):
 
     def __init__(self):
         """Create instance of class"""
+        super(SignatureAlgorithmsExtension, self).__init__(extType=
+                                                           ExtensionType.
+                                                           signature_algorithms)
         self.sigalgs = None
-
-    @property
-    def extType(self):
-        """
-        Type of extension, in this case - 13
-
-        @rtype: int
-        """
-        return ExtensionType.signature_algorithms
 
     @property
     def extData(self):

--- a/unit_tests/test_tlslite_extensions.py
+++ b/unit_tests/test_tlslite_extensions.py
@@ -11,7 +11,7 @@ except ImportError:
 from tlslite.extensions import TLSExtension, SNIExtension, NPNExtension,\
         SRPExtension, ClientCertTypeExtension, ServerCertTypeExtension,\
         TACKExtension, SupportedGroupsExtension, ECPointFormatsExtension,\
-        SignatureAlgorithmsExtension
+        SignatureAlgorithmsExtension, VarListExtension
 from tlslite.utils.codec import Parser
 from tlslite.constants import NameType, ExtensionType, GroupName,\
         ECPointFormat, HashAlgorithm, SignatureAlgorithm
@@ -292,6 +292,28 @@ class TestTLSExtension(unittest.TestCase):
         self.assertEqual("TLSExtension(extType=0, "\
                 "extData=bytearray(b'\\x00\\x00'), serverType=False)",
                 repr(ext))
+
+class TestVarListExtension(unittest.TestCase):
+    def setUp(self):
+        self.ext = VarListExtension(1, 1, 'groups', 42)
+
+    def test___init__(self):
+        self.assertIsNotNone(self.ext)
+
+    def test_get_attribute(self):
+        self.assertIsNone(self.ext.groups)
+
+    def test_set_attribute(self):
+        self.ext.groups = [1, 2, 3]
+
+        self.assertEqual(self.ext.groups, [1, 2, 3])
+
+    def test_get_non_existant_attribute(self):
+        with self.assertRaises(AttributeError) as e:
+            val = self.ext.gruppen
+
+        self.assertEqual(str(e.exception),
+                "type object 'VarListExtension' has no attribute 'gruppen'")
 
 class TestSNIExtension(unittest.TestCase):
     def test___init__(self):
@@ -648,7 +670,7 @@ class TestClientCertTypeExtension(unittest.TestCase):
 
     def test_create(self):
         cert_type = ClientCertTypeExtension()
-        cert_type = cert_type.create()
+        cert_type = cert_type.create(None)
 
         self.assertEqual(9, cert_type.extType)
         self.assertEqual(bytearray(0), cert_type.extData)
@@ -1217,6 +1239,11 @@ class TestSupportedGroups(unittest.TestCase):
         with self.assertRaises(SyntaxError):
             ext.parse(parser)
 
+    def test_repr(self):
+        ext = SupportedGroupsExtension().create([GroupName.secp256r1])
+        self.assertEqual("SupportedGroupsExtension(groups=[23])",
+                repr(ext))
+
 class TestECPointFormatsExtension(unittest.TestCase):
     def test___init__(self):
         ext = ECPointFormatsExtension()
@@ -1251,6 +1278,10 @@ class TestECPointFormatsExtension(unittest.TestCase):
         ext.parse(parser)
 
         self.assertIsNone(ext.formats)
+
+    def test_repr(self):
+        ext = ECPointFormatsExtension().create([ECPointFormat.uncompressed])
+        self.assertEqual("ECPointFormatsExtension(formats=[0])", repr(ext))
 
 class TestSignatureAlgorithmsExtension(unittest.TestCase):
     def test__init__(self):

--- a/unit_tests/test_tlslite_extensions.py
+++ b/unit_tests/test_tlslite_extensions.py
@@ -28,9 +28,60 @@ class TestTLSExtension(unittest.TestCase):
     def test_create(self):
         tls_extension = TLSExtension().create(1, bytearray(b'\x01\x00'))
 
-        assert tls_extension
+        self.assertIsNotNone(tls_extension)
         self.assertEqual(1, tls_extension.extType)
         self.assertEqual(bytearray(b'\x01\x00'), tls_extension.extData)
+
+    def test_new_style_create(self):
+        tls_extension = TLSExtension(extType=1).create(bytearray(b'\x01\x00'))
+
+        self.assertIsNotNone(tls_extension)
+        self.assertEqual(1, tls_extension.extType)
+        self.assertEqual(bytearray(b'\x01\x00'), tls_extension.extData)
+
+    def test_new_style_create_with_keyword(self):
+        tls_extension = TLSExtension(extType=1).create(data=\
+                bytearray(b'\x01\x00'))
+
+        self.assertIsNotNone(tls_extension)
+        self.assertEqual(1, tls_extension.extType)
+        self.assertEqual(bytearray(b'\x01\x00'), tls_extension.extData)
+
+    def test_new_style_create_with_invalid_keyword(self):
+        with self.assertRaises(TypeError):
+            TLSExtension(extType=1).create(extData=bytearray(b'\x01\x00'))
+
+    def test_old_style_create_with_keyword_args(self):
+        tls_extension = TLSExtension().create(extType=1,
+                                              data=bytearray(b'\x01\x00'))
+        self.assertIsNotNone(tls_extension)
+        self.assertEqual(1, tls_extension.extType)
+        self.assertEqual(bytearray(b'\x01\x00'), tls_extension.extData)
+
+    def test_old_style_create_with_one_keyword_arg(self):
+        tls_extension = TLSExtension().create(1,
+                                              data=bytearray(b'\x01\x00'))
+        self.assertIsNotNone(tls_extension)
+        self.assertEqual(1, tls_extension.extType)
+        self.assertEqual(bytearray(b'\x01\x00'), tls_extension.extData)
+
+    def test_old_style_create_with_invalid_keyword_name(self):
+        with self.assertRaises(TypeError):
+            TLSExtension().create(1,
+                                  extData=bytearray(b'\x01\x00'))
+
+    def test_old_style_create_with_duplicate_keyword_name(self):
+        with self.assertRaises(TypeError):
+            TLSExtension().create(1,
+                                  extType=1)
+
+    def test_create_with_too_few_args(self):
+        with self.assertRaises(TypeError):
+            TLSExtension().create()
+
+    def test_create_with_too_many_args(self):
+        with self.assertRaises(TypeError):
+            TLSExtension().create(1, 2, 3)
 
     def test_write(self):
         tls_extension = TLSExtension()


### PR DESCRIPTION
since the on-the-wire encoding of those extensions is (almost)
identical, we can create an "abstract" extension that implements them
all and just depends on specific initialization