### PR TITLE
Padding extension support to tlslite

### DIFF
--- a/tlslite/constants.py
+++ b/tlslite/constants.py
@@ -86,6 +86,7 @@ class ExtensionType:    # RFC 6066 / 4366
     ec_point_formats = 11 # RFC 4492
     srp = 12            # RFC 5054
     signature_algorithms = 13 # RFC 5246
+    client_hello_padding = 21 # RFC 7685
     encrypt_then_mac = 22 # RFC 7366
     tack = 0xF300
     supports_npn = 13172

--- a/tlslite/extensions.py
+++ b/tlslite/extensions.py
@@ -1118,6 +1118,65 @@ class SignatureAlgorithmsExtension(TLSExtension):
 
         return self
 
+class PaddingExtension(TLSExtension):
+
+    """
+    ClientHello message padding with a desired size.
+
+    Can be used to pad ClientHello messages to a desired size
+    in order to avoid implementation bugs caused by certain
+    ClientHello sizes.
+
+    See RFC7685.
+    """
+
+    def __init__(self):
+        """Create instance of class"""
+        self.paddingData = bytearray(0)
+
+    @property
+    def extType(self):
+        """
+        Type of extension, in this case - 21
+
+        @rtype: int
+        """
+        return ExtensionType.client_hello_padding
+
+    @property
+    def extData(self):
+        """
+        Return raw encoding of the extension
+
+        @rtype: bytearray
+        """
+        return self.paddingData
+
+    def create(self, size):
+        """
+        Set the padding size and create null byte padding of defined size
+
+        @type size: int
+        @param size: required padding size in bytes
+        """
+        self.paddingData = bytearray(size)
+        return self
+
+    def parse(self, p):
+        """
+        Deserialise extension from on the wire data
+
+        @type p: L{tlslite.util.codec.Parser}
+        @param p:  data to be parsed
+
+        @raise SyntaxError: when the size of the passed element doesn't match
+        the internal representation
+
+        @rtype: L{TLSExtension}
+        """
+        self.paddingData = p.getFixBytes(p.getRemainingLength())
+        return self
+
 TLSExtension._universalExtensions = \
     {
         ExtensionType.server_name : SNIExtension,
@@ -1126,7 +1185,8 @@ TLSExtension._universalExtensions = \
         ExtensionType.ec_point_formats : ECPointFormatsExtension,
         ExtensionType.srp : SRPExtension,
         ExtensionType.signature_algorithms : SignatureAlgorithmsExtension,
-        ExtensionType.supports_npn : NPNExtension}
+        ExtensionType.supports_npn : NPNExtension,
+        ExtensionType.client_hello_padding : PaddingExtension}
 
 TLSExtension._serverExtensions = \
     {

--- a/tlslite/handshakehelpers.py
+++ b/tlslite/handshakehelpers.py
@@ -1,0 +1,41 @@
+# Authors:
+#   Karel Srot
+#
+# See the LICENSE file for legal information regarding use of this file.
+
+"""
+Class with various handshake helpers.
+"""
+
+from .extensions import PaddingExtension
+
+class HandshakeHelpers(object):
+    """
+    This class encapsulates helper functions to be used with a TLS handshake.
+
+    @sort: alignUsingPaddingExtension
+    """
+    @staticmethod
+    def alignClientHelloPadding(clientHello):
+        """
+        Aligns ClientHello using the Padding extension to 512 bytes at least.
+
+        @type data: ClientHello
+        @param data: ClientHello to be aligned
+        """
+        # Check clientHello size if padding extension should be added
+        # we want to add the extension even when using just SSLv3
+        # cut-off 4 bytes with the Hello header (ClientHello type + Length)
+        clientHelloLength = len(clientHello.write()) - 4
+        if 256 <= clientHelloLength <= 511:
+            if clientHello.extensions is None:
+                clientHello.extensions = []
+                # we need to recalculate the size after extension list addition
+                # results in extra 2 bytes, equals to
+                # clientHelloLength = len(clientHello.write()) - 4
+                clientHelloLength += 2
+            # we want to get 512 bytes in total, including the padding
+            # extension header (4B)
+            paddingExtensionInstance = PaddingExtension().create(
+                max(512 - clientHelloLength - 4, 0))
+            clientHello.extensions.append(paddingExtensionInstance)

--- a/tlslite/handshakesettings.py
+++ b/tlslite/handshakesettings.py
@@ -140,6 +140,7 @@ class HandshakeSettings(object):
         self.useEncryptThenMAC = True
         self.rsaSigHashes = list(RSA_SIGNATURE_HASHES)
         self.eccCurves = list(CURVE_NAMES)
+        self.usePaddingExtension = True
 
     @staticmethod
     def _sanityCheckKeySizes(other):
@@ -189,9 +190,6 @@ class HandshakeSettings(object):
         if unknownCurve:
             raise ValueError("Unknown ECC Curve name: {0}".format(unknownCurve))
 
-        if other.useEncryptThenMAC not in (True, False):
-            raise ValueError("useEncryptThenMAC can only be True or False")
-
         unknownSigHash = [val for val in other.rsaSigHashes \
                           if val not in ALL_RSA_SIGNATURE_HASHES]
         if unknownSigHash:
@@ -207,6 +205,15 @@ class HandshakeSettings(object):
             raise ValueError("minVersion set incorrectly")
         if other.maxVersion not in ((3, 0), (3, 1), (3, 2), (3, 3)):
             raise ValueError("maxVersion set incorrectly")
+
+    @staticmethod
+    def _sanityCheckExtensions(other):
+        """Check if set extension settings are sane"""
+        if other.useEncryptThenMAC not in (True, False):
+            raise ValueError("useEncryptThenMAC can only be True or False")
+
+        if other.usePaddingExtension not in (True, False):
+            raise ValueError("usePaddingExtension must be True or False")
 
     def validate(self):
         """
@@ -229,6 +236,7 @@ class HandshakeSettings(object):
         other.maxVersion = self.maxVersion
         other.sendFallbackSCSV = self.sendFallbackSCSV
         other.useEncryptThenMAC = self.useEncryptThenMAC
+        other.usePaddingExtension = self.usePaddingExtension
         other.rsaSigHashes = self.rsaSigHashes
         other.eccCurves = self.eccCurves
 
@@ -253,6 +261,8 @@ class HandshakeSettings(object):
         self._sanityCheckPrimitivesNames(other)
 
         self._sanityCheckProtocolVersions(other)
+
+        self._sanityCheckExtensions(other)
 
         if other.maxVersion < (3,3):
             # No sha-2 and AEAD pre TLS 1.2

--- a/tlslite/tlsconnection.py
+++ b/tlslite/tlsconnection.py
@@ -29,6 +29,7 @@ from .handshakesettings import HandshakeSettings
 from .utils.tackwrapper import *
 from .keyexchange import KeyExchange, RSAKeyExchange, DHE_RSAKeyExchange, \
         ECDHE_RSAKeyExchange, SRPKeyExchange
+from .handshakehelpers import HandshakeHelpers
 
 class TLSConnection(TLSRecordLayer):
     """
@@ -592,6 +593,12 @@ class TLSConnection(TLSRecordLayer):
                                reqTack, nextProtos is not None, 
                                serverName,
                                extensions=extensions)
+
+        # Check if padding extension should be added
+        # we want to add extensions even when using just SSLv3
+        if settings.usePaddingExtension:
+            HandshakeHelpers.alignClientHelloPadding(clientHello)
+
         for result in self._sendMsg(clientHello):
             yield result
         yield clientHello

--- a/unit_tests/test_tlslite_handshakehelpers.py
+++ b/unit_tests/test_tlslite_handshakehelpers.py
@@ -1,0 +1,161 @@
+# Copyright (c) 2014, Karel Srot
+#
+# See the LICENSE file for legal information regarding use of this file.
+
+# compatibility with Python 2.6, for that we need unittest2 package,
+# which is not available on 3.3 or 3.4
+try:
+    import unittest2 as unittest
+except ImportError:
+    import unittest
+from tlslite.handshakehelpers import HandshakeHelpers
+from tlslite.messages import ClientHello
+from tlslite.extensions import SNIExtension
+
+class TestHandshakeHelpers(unittest.TestCase):
+    def test_alignClientHelloPadding_length_less_than_256_bytes(self):
+        clientHello = ClientHello()
+        clientHello.create((3,0), bytearray(32), bytearray(0), [])
+
+        clientHelloLength = len(clientHello.write())
+        self.assertTrue(clientHelloLength - 4 < 256)
+
+        HandshakeHelpers.alignClientHelloPadding(clientHello)
+
+        # clientHello should not be changed due to small length
+        self.assertEqual(clientHelloLength, len(clientHello.write()))
+
+    def test_alignClientHelloPadding_length_256_bytes(self):
+        clientHello = ClientHello()
+        clientHello.create((3,0), bytearray(32), bytearray(0), [])
+        clientHello.extensions = []
+
+        ext = SNIExtension()
+        ext.create(hostNames=[
+            bytearray(b'aaaaaaaaaabbbbbbbbbbccccccccccddddddddddeeeeeeeeee'),
+            bytearray(b'aaaaaaaaaabbbbbbbbbbccccccccccddddddddddeeeeeeeeee'),
+            bytearray(b'aaaaaaaaaabbbbbbbbbbccccccccccddddddddddeeeeeeeeee'),
+            bytearray(b'aaaaaaaaaabbbbbbbbbbccccccccccddddddddddeeeeeee'),
+        ])
+        clientHello.extensions.append(ext)
+        clientHelloLength = len(clientHello.write())
+        # clientHello length (excluding 4B header) should equal to 256
+        self.assertEqual(256, clientHelloLength - 4)
+
+        HandshakeHelpers.alignClientHelloPadding(clientHello)
+
+        # clientHello length (excluding 4B header) should equal to 512
+        data = clientHello.write()
+        self.assertEqual(512, len(data) - 4)
+        # previously created data should be extended with the padding extension
+        # starting with the padding extension type \x00\x15 (21)
+        self.assertEqual(bytearray(b'\x00\x15'), data[clientHelloLength:clientHelloLength+2])
+
+    def test_alignClientHelloPadding_length_of_508_bytes(self):
+        clientHello = ClientHello()
+        clientHello.create((3,0), bytearray(32), bytearray(0), [])
+        clientHello.extensions = []
+
+        ext = SNIExtension()
+        ext.create(hostNames=[
+            bytearray(b'aaaaaaaaaabbbbbbbbbbccccccccccddddddddddeeeeeeeeee'),
+            bytearray(b'aaaaaaaaaabbbbbbbbbbccccccccccddddddddddeeeeeeeeee'),
+            bytearray(b'aaaaaaaaaabbbbbbbbbbccccccccccddddddddddeeeeeeeeee'),
+            bytearray(b'aaaaaaaaaabbbbbbbbbbccccccccccddddddddddeeeeeeeeee'),
+            bytearray(b'aaaaaaaaaabbbbbbbbbbccccccccccddddddddddeeeeeeeeee'),
+            bytearray(b'aaaaaaaaaabbbbbbbbbbccccccccccddddddddddeeeeeeeeee'),
+            bytearray(b'aaaaaaaaaabbbbbbbbbbccccccccccddddddddddeeeeeeeeee'),
+            bytearray(b'aaaaaaaaaabbbbbbbbbbccccccccccddddddddddeeeeeeeeee'),
+            bytearray(b'aaaaaaaaaabbbbbbbbbbccccccccccdddd'),
+        ])
+        clientHello.extensions.append(ext)
+        clientHelloLength = len(clientHello.write())
+        self.assertEqual(508, clientHelloLength - 4)
+
+        HandshakeHelpers.alignClientHelloPadding(clientHello)
+
+        # clientHello length should equal to 512, ignoring handshake
+        # protocol header (4B)
+        data = clientHello.write()
+        self.assertEqual(512, len(data) - 4)
+        # padding extension should have zero byte size
+        self.assertEqual(bytearray(b'\x00\x15\x00\x00'), data[clientHelloLength:])
+
+    def test_alignClientHelloPadding_length_of_511_bytes(self):
+        clientHello = ClientHello()
+        clientHello.create((3,0), bytearray(32), bytearray(0), [])
+        clientHello.extensions = []
+
+        ext = SNIExtension()
+        ext.create(hostNames=[
+            bytearray(b'aaaaaaaaaabbbbbbbbbbccccccccccddddddddddeeeeeeeeee'),
+            bytearray(b'aaaaaaaaaabbbbbbbbbbccccccccccddddddddddeeeeeeeeee'),
+            bytearray(b'aaaaaaaaaabbbbbbbbbbccccccccccddddddddddeeeeeeeeee'),
+            bytearray(b'aaaaaaaaaabbbbbbbbbbccccccccccddddddddddeeeeeeeeee'),
+            bytearray(b'aaaaaaaaaabbbbbbbbbbccccccccccddddddddddeeeeeeeeee'),
+            bytearray(b'aaaaaaaaaabbbbbbbbbbccccccccccddddddddddeeeeeeeeee'),
+            bytearray(b'aaaaaaaaaabbbbbbbbbbccccccccccddddddddddeeeeeeeeee'),
+            bytearray(b'aaaaaaaaaabbbbbbbbbbccccccccccddddddddddeeeeeeeeee'),
+            bytearray(b'aaaaaaaaaabbbbbbbbbbccccccccccddddddd'),
+        ])
+        clientHello.extensions.append(ext)
+        clientHelloLength = len(clientHello.write())
+        self.assertEqual(511, clientHelloLength - 4)
+
+        HandshakeHelpers.alignClientHelloPadding(clientHello)
+
+        # clientHello length should equal to 515, ignoring handshake
+        # protocol header (4B)
+        data = clientHello.write()
+        self.assertEqual(515, len(data) - 4)
+        # padding extension should have zero byte size
+        self.assertEqual(bytearray(b'\x00\x15\x00\x00'), data[clientHelloLength:])
+
+
+    def test_alignClientHelloPadding_length_of_512_bytes(self):
+        clientHello = ClientHello()
+        clientHello.create((3,0), bytearray(32), bytearray(0), [])
+        clientHello.extensions = []
+
+        ext = SNIExtension()
+        ext.create(hostNames=[
+            bytearray(b'aaaaaaaaaabbbbbbbbbbccccccccccddddddddddeeeeeeeeee'),
+            bytearray(b'aaaaaaaaaabbbbbbbbbbccccccccccddddddddddeeeeeeeeee'),
+            bytearray(b'aaaaaaaaaabbbbbbbbbbccccccccccddddddddddeeeeeeeeee'),
+            bytearray(b'aaaaaaaaaabbbbbbbbbbccccccccccddddddddddeeeeeeeeee'),
+            bytearray(b'aaaaaaaaaabbbbbbbbbbccccccccccddddddddddeeeeeeeeee'),
+            bytearray(b'aaaaaaaaaabbbbbbbbbbccccccccccddddddddddeeeeeeeeee'),
+            bytearray(b'aaaaaaaaaabbbbbbbbbbccccccccccddddddddddeeeeeeeeee'),
+            bytearray(b'aaaaaaaaaabbbbbbbbbbccccccccccddddddddddeeeeeeeeee'),
+            bytearray(b'aaaaaaaaaabbbbbbbbbbccccccccccdddddddd'),
+        ])
+        clientHello.extensions.append(ext)
+        clientHelloLength = len(clientHello.write())
+        self.assertEqual(512, clientHelloLength - 4)
+
+        HandshakeHelpers.alignClientHelloPadding(clientHello)
+
+        # clientHello should not be changed due to sufficient length (>=512)
+        self.assertEqual(clientHelloLength, len(clientHello.write()))
+
+    def test_alignClientHelloPadding_extension_list_initialization(self):
+        clientHello = ClientHello()
+        clientHello.create((3,0), bytearray(32), bytearray(0), range(0, 129))
+
+        clientHelloLength = len(clientHello.write())
+        self.assertTrue(512 > clientHelloLength - 4 > 255)
+
+        HandshakeHelpers.alignClientHelloPadding(clientHello)
+
+        # verify that the extension list has been added to clientHello
+        self.assertTrue(type(clientHello.extensions) is list)
+        # clientHello length should equal to 512, ignoring handshake
+        # protocol header (4B)
+        data = clientHello.write()
+        self.assertEqual(512, len(data) - 4)
+        # padding extension should have been added after 2 extra bytes
+        # added due to an extension list
+        self.assertEqual(bytearray(b'\x00\x15'), data[clientHelloLength+2:clientHelloLength+4])
+
+if __name__ == '__main__':
+    unittest.main()

--- a/unit_tests/test_tlslite_handshakesettings.py
+++ b/unit_tests/test_tlslite_handshakesettings.py
@@ -207,3 +207,16 @@ class TestHandshakeSettings(unittest.TestCase):
         hs.eccCurves = ['P-256']
         with self.assertRaises(ValueError):
             hs.validate()
+
+    def test_usePaddingExtension(self):
+        hs = HandshakeSettings()
+        self.assertTrue(hs.usePaddingExtension)
+
+    def test_invalid_usePaddingExtension(self):
+        hs = HandshakeSettings()
+        hs.usePaddingExtension = -1
+        with self.assertRaises(ValueError):
+            hs.validate()
+
+if __name__ == '__main__':
+    unittest.main()


### PR DESCRIPTION
Implements TLS extension described in RFC 7685 that can be used to pad a ClientHello with sized between 256 and 511 bytes in order to avoid implementation bugs caused by certain ClientHello sizes.

fixes #63 