### PR TITLE
allow subclassing TLSEnum subclasses

### DIFF
--- a/tlslite/constants.py
+++ b/tlslite/constants.py
@@ -14,15 +14,25 @@ class TLSEnum(object):
     """Base class for different enums of TLS IDs"""
 
     @classmethod
+    def _recursiveVars(cls, klass):
+        """Call vars recursively on base classes"""
+        fields = dict()
+        for basecls in klass.__bases__:
+            fields.update(cls._recursiveVars(basecls))
+        fields.update(dict(vars(klass)))
+        return fields
+
+    @classmethod
     def toRepr(cls, value, blacklist=None):
         """
         Convert numeric type to string representation
 
         name if found, None otherwise
         """
+        fields = cls._recursiveVars(cls)
         if blacklist is None:
             blacklist = []
-        return next((key for key, val in cls.__dict__.items() \
+        return next((key for key, val in fields.items() \
                     if key not in ('__weakref__', '__dict__', '__doc__',
                                    '__module__') and \
                        key not in blacklist and \

--- a/unit_tests/test_tlslite_constants.py
+++ b/unit_tests/test_tlslite_constants.py
@@ -10,7 +10,24 @@ except ImportError:
     import unittest
 
 from tlslite.constants import CipherSuite, HashAlgorithm, SignatureAlgorithm, \
-        ContentType, AlertDescription, AlertLevel, HandshakeType, GroupName
+        ContentType, AlertDescription, AlertLevel, HandshakeType, GroupName, \
+        TLSEnum
+
+class TestTLSEnumSubClassing(unittest.TestCase):
+
+    class SubClass(TLSEnum):
+        value = 1
+
+    def test_toRepr(self):
+        self.assertEqual(self.SubClass.toStr(1), 'value')
+
+    class SubSubClass(SubClass):
+        new_value = 2
+
+    def test_toRepr_SubSubClass(self):
+        self.assertEqual(self.SubSubClass.toStr(1), 'value')
+        self.assertEqual(self.SubSubClass.toStr(2), 'new_value')
+
 
 class TestHashAlgorithm(unittest.TestCase):
 


### PR DESCRIPTION
because both the `__dict__` and `vars()` return the values
of the current class, not all the classes in hierarchy, we need to
manually traverse the hierarchy and collect all the fields ourselves

this allows for extending the subclasses of TLSEnum subclasses and
making both toRepr() and toStr() continue to work