### PR TITLE
Fix library in FIPS mode

### DIFF
--- a/pylintrc
+++ b/pylintrc
@@ -44,7 +44,7 @@ symbols=no
 # --enable=similarities". If you want to run only the classes checker, but have
 # no Warning level messages displayed, use"--disable=all --enable=classes
 # --disable=W"
-#disable=
+disable=locally-disabled,locally-enabled
 
 
 [REPORTS]

--- a/tlslite/handshakehashes.py
+++ b/tlslite/handshakehashes.py
@@ -5,7 +5,7 @@
 
 from .utils.compat import compat26Str, compatHMAC
 from .utils.cryptomath import MD5, SHA1
-import hashlib
+from .utils import tlshashlib as hashlib
 
 class HandshakeHashes(object):
 

--- a/tlslite/mathtls.py
+++ b/tlslite/mathtls.py
@@ -11,6 +11,7 @@
 from .utils.compat import *
 from .utils.cryptomath import *
 from .constants import CipherSuite
+from .utils import tlshashlib as hashlib
 
 import hmac
 

--- a/tlslite/recordlayer.py
+++ b/tlslite/recordlayer.py
@@ -6,7 +6,7 @@
 
 import socket
 import errno
-import hashlib
+from .utils import tlshashlib as hashlib
 from .constants import ContentType, CipherSuite
 from .messages import RecordHeader3, RecordHeader2, Message
 from .utils.cipherfactory import createAESGCM, createAES, createRC4, \

--- a/tlslite/utils/cryptomath.py
+++ b/tlslite/utils/cryptomath.py
@@ -27,6 +27,14 @@ try:
     from M2Crypto import m2
     m2cryptoLoaded = True
 
+    try:
+        with open('/proc/sys/crypto/fips_enabled', 'r') as fipsFile:
+            if '1' in fipsFile.read():
+                m2cryptoLoaded = False
+    except (IOError, OSError):
+        # looks like we're running in container, likely not FIPS mode
+        m2cryptoLoaded = True
+
 except ImportError:
     m2cryptoLoaded = False
 
@@ -67,7 +75,7 @@ prngName = "os.urandom"
 # **************************************************************************
 
 import hmac
-import hashlib
+from . import tlshashlib as hashlib
 
 def MD5(b):
     """Return a MD5 digest of data"""

--- a/tlslite/utils/cryptomath.py
+++ b/tlslite/utils/cryptomath.py
@@ -15,7 +15,7 @@ import base64
 import binascii
 import sys
 
-from .compat import *
+from .compat import compat26Str, compatHMAC, compatLong
 
 
 # **************************************************************************

--- a/tlslite/utils/tlshashlib.py
+++ b/tlslite/utils/tlshashlib.py
@@ -1,0 +1,32 @@
+# Author: Hubert Kario (c) 2015
+# see LICENCE file for legal information regarding use of this file
+
+"""hashlib that handles FIPS mode."""
+
+# Because we are extending the hashlib module, we need to import all its
+# fields to suppport the same uses
+# pylint: disable=unused-wildcard-import, wildcard-import
+from hashlib import *
+# pylint: enable=unused-wildcard-import, wildcard-import
+import hashlib
+
+
+def _fipsFunction(func, *args, **kwargs):
+    """Make hash function support FIPS mode."""
+    try:
+        return func(*args, **kwargs)
+    except ValueError:
+        return func(*args, usedforsecurity=False, **kwargs)
+
+
+# redefining the function is exactly what we intend to do
+# pylint: disable=function-redefined
+def md5(*args, **kwargs):
+    """MD5 constructor that works in FIPS mode."""
+    return _fipsFunction(hashlib.md5, *args, **kwargs)
+
+
+def new(*args, **kwargs):
+    """General constructor that works in FIPS mode."""
+    return _fipsFunction(hashlib.new, *args, **kwargs)
+# pylint: enable=function-redefined

--- a/unit_tests/test_tlslite_utils_constanttime.py
+++ b/unit_tests/test_tlslite_utils_constanttime.py
@@ -15,7 +15,7 @@ from tlslite.utils.constanttime import ct_lt_u32, ct_gt_u32, ct_le_u32, \
 
 from tlslite.utils.compat import compatHMAC
 from tlslite.recordlayer import RecordLayer
-import hashlib
+import tlslite.utils.tlshashlib as hashlib
 import hmac
 
 class TestContanttime(unittest.TestCase):

--- a/unit_tests/test_tlslite_utils_cryptomath_m2crypto.py
+++ b/unit_tests/test_tlslite_utils_cryptomath_m2crypto.py
@@ -1,0 +1,106 @@
+# Copyright (c) 2014, Hubert Kario
+#
+# See the LICENSE file for legal information regarding use of this file.
+
+# compatibility with Python 2.6, for that we need unittest2 package,
+# which is not available on 3.3 or 3.4
+try:
+    import unittest2 as unittest
+except ImportError:
+    import unittest
+try:
+    import mock
+    from mock import call
+except ImportError:
+    import unittest.mock as mock
+    from unittest.mock import call
+import sys
+try:
+    # Python 2
+    reload
+except NameError:
+    try:
+        # Python >= 3.4
+        from importlib import reload
+    except ImportError:
+        # Python <= 3.3
+        from imp import reload
+try:
+    import __builtin__ as builtins
+except ImportError:
+    import builtins
+
+real_open = builtins.open
+
+class magic_open(object):
+    def __init__(self, *args, **kwargs):
+        self.args = args
+        self.kwargs = kwargs
+
+    def __enter__(self):
+        if self.args[0] == '/proc/sys/crypto/fips_enabled':
+            m = mock.MagicMock()
+            m.read.return_value = '1'
+            self.f = m
+            return m
+        else:
+            self.f = real_open(*self.args, **self.kwargs)
+            return self.f
+
+    def __exit__(self, exc_type, exc_value, exc_traceback):
+        self.f.close()
+
+class magic_open_error(object):
+    def __init__(self, *args, **kwargs):
+        self.args = args
+        self.kwargs = kwargs
+
+    def __enter__(self):
+        if self.args[0] == '/proc/sys/crypto/fips_enabled':
+            m = mock.MagicMock()
+            self.f = m
+            raise IOError(12)
+        else:
+            self.f = real_open(*self.args, **self.kwargs)
+            return self.f
+
+    def __exit__(self, exc_type, exc_value, exc_traceback):
+        self.f.close()
+
+
+class TestM2CryptoLoaded(unittest.TestCase):
+    def test_import_without_m2crypto(self):
+        with mock.patch.dict('sys.modules', {'M2Crypto': None}):
+            import tlslite.utils.cryptomath
+            reload(tlslite.utils.cryptomath)
+            from tlslite.utils.cryptomath import m2cryptoLoaded
+            self.assertFalse(m2cryptoLoaded)
+
+    def test_import_with_m2crypto(self):
+        fake_m2 = mock.MagicMock()
+
+        with mock.patch.dict('sys.modules', {'M2Crypto': fake_m2}):
+            import tlslite.utils.cryptomath
+            reload(tlslite.utils.cryptomath)
+            from tlslite.utils.cryptomath import m2cryptoLoaded
+            self.assertTrue(m2cryptoLoaded)
+
+    def test_import_with_m2crypto_in_fips_mode(self):
+        fake_m2 = mock.MagicMock()
+
+        with mock.patch.dict('sys.modules', {'M2Crypto': fake_m2}):
+            with mock.patch.object(builtins, 'open', magic_open):
+                import tlslite.utils.cryptomath
+                reload(tlslite.utils.cryptomath)
+                from tlslite.utils.cryptomath import m2cryptoLoaded
+                self.assertFalse(m2cryptoLoaded)
+
+    def test_import_with_m2crypto_in_container(self):
+        fake_m2 = mock.MagicMock()
+
+        with mock.patch.dict('sys.modules', {'M2Crypto': fake_m2}):
+            with mock.patch.object(builtins, 'open', magic_open_error):
+                import tlslite.utils.cryptomath
+                reload(tlslite.utils.cryptomath)
+                from tlslite.utils.cryptomath import m2cryptoLoaded
+                self.assertTrue(m2cryptoLoaded)

--- a/unit_tests/test_tlslite_utils_tlshashlib.py
+++ b/unit_tests/test_tlslite_utils_tlshashlib.py
@@ -1,0 +1,27 @@
+# Copyright (c) 2014, Hubert Kario
+#
+# See the LICENSE file for legal information regarding use of this file.
+
+# compatibility with Python 2.6, for that we need unittest2 package,
+# which is not available on 3.3 or 3.4
+try:
+    import unittest2 as unittest
+except ImportError:
+    import unittest
+try:
+    import mock
+    from mock import call
+except ImportError:
+    import unittest.mock as mock
+    from unittest.mock import call
+
+class TestTLSHashlib(unittest.TestCase):
+
+    def test_in_fips_mode(self):
+        def m(*args, **kwargs):
+            if 'usedforsecurity' not in kwargs:
+                raise ValueError("MD5 disabled in FIPS mode")
+
+        with mock.patch('hashlib.md5', m):
+            from tlslite.utils.tlshashlib import md5
+            md5()


### PR DESCRIPTION
there are some additional limitations on behaviour of `m2crypto` and `hashlib` when system is working in FIPS mode - workaround those