### PR TITLE
fix testing of FIPS workaround

### DIFF
--- a/unit_tests/test_tlslite_utils_cryptomath_m2crypto.py
+++ b/unit_tests/test_tlslite_utils_cryptomath_m2crypto.py
@@ -104,3 +104,8 @@ class TestM2CryptoLoaded(unittest.TestCase):
                 reload(tlslite.utils.cryptomath)
                 from tlslite.utils.cryptomath import m2cryptoLoaded
                 self.assertTrue(m2cryptoLoaded)
+
+    @classmethod
+    def tearDownClass(cls):
+        import tlslite.utils.cryptomath
+        reload(tlslite.utils.cryptomath)


### PR DESCRIPTION
because we're messing with how the whole module behaves, regular
mock.patch cannot clean up after us, as such we need to reload
the whole module after the testing is done to not affect other
tests