### PR TITLE
Chacha20 speedup

### DIFF
--- a/tlslite/utils/chacha.py
+++ b/tlslite/utils/chacha.py
@@ -25,7 +25,6 @@ class ChaCha(object):
     @staticmethod
     def quarter_round(x, a, b, c, d):
         """Perform a ChaCha quarter round"""
-        rotl32 = ChaCha.rotl32
         xa = x[a]
         xb = x[b]
         xc = x[c]
@@ -33,19 +32,19 @@ class ChaCha(object):
 
         xa = (xa + xb) & 0xffffffff
         xd = xd ^ xa
-        xd = rotl32(xd, 16)
+        xd = ((xd << 16) & 0xffffffff | (xd >> 16))
 
         xc = (xc + xd) & 0xffffffff
         xb = xb ^ xc
-        xb = rotl32(xb, 12)
+        xb = ((xb << 12) & 0xffffffff | (xb >> 20))
 
         xa = (xa + xb) & 0xffffffff
         xd = xd ^ xa
-        xd = rotl32(xd, 8)
+        xd = ((xd << 8) & 0xffffffff | (xd >> 24))
 
         xc = (xc + xd) & 0xffffffff
         xb = xb ^ xc
-        xb = rotl32(xb, 7)
+        xb = ((xb << 7) & 0xffffffff | (xb >> 25))
 
         x[a] = xa
         x[b] = xb

--- a/tlslite/utils/chacha.py
+++ b/tlslite/utils/chacha.py
@@ -25,33 +25,35 @@ class ChaCha(object):
     @staticmethod
     def quarter_round(x, a, b, c, d):
         """Perform a ChaCha quarter round"""
+        rotl32 = ChaCha.rotl32
         x[a] = (x[a] + x[b]) & 0xffffffff
         x[d] = x[d] ^ x[a]
-        x[d] = ChaCha.rotl32(x[d], 16)
+        x[d] = rotl32(x[d], 16)
 
         x[c] = (x[c] + x[d]) & 0xffffffff
         x[b] = x[b] ^ x[c]
-        x[b] = ChaCha.rotl32(x[b], 12)
+        x[b] = rotl32(x[b], 12)
 
         x[a] = (x[a] + x[b]) & 0xffffffff
         x[d] = x[d] ^ x[a]
-        x[d] = ChaCha.rotl32(x[d], 8)
+        x[d] = rotl32(x[d], 8)
 
         x[c] = (x[c] + x[d]) & 0xffffffff
         x[b] = x[b] ^ x[c]
-        x[b] = ChaCha.rotl32(x[b], 7)
+        x[b] = rotl32(x[b], 7)
 
     @staticmethod
     def double_round(x):
         """Perform two rounds of ChaCha cipher"""
-        ChaCha.quarter_round(x, 0, 4, 8, 12)
-        ChaCha.quarter_round(x, 1, 5, 9, 13)
-        ChaCha.quarter_round(x, 2, 6, 10, 14)
-        ChaCha.quarter_round(x, 3, 7, 11, 15)
-        ChaCha.quarter_round(x, 0, 5, 10, 15)
-        ChaCha.quarter_round(x, 1, 6, 11, 12)
-        ChaCha.quarter_round(x, 2, 7, 8, 13)
-        ChaCha.quarter_round(x, 3, 4, 9, 14)
+        qr = ChaCha.quarter_round
+        qr(x, 0, 4, 8, 12)
+        qr(x, 1, 5, 9, 13)
+        qr(x, 2, 6, 10, 14)
+        qr(x, 3, 7, 11, 15)
+        qr(x, 0, 5, 10, 15)
+        qr(x, 1, 6, 11, 12)
+        qr(x, 2, 7, 8, 13)
+        qr(x, 3, 4, 9, 14)
 
     @staticmethod
     def chacha_block(key, counter, nonce, rounds):
@@ -63,8 +65,9 @@ class ChaCha(object):
         state.extend(nonce)
 
         working_state = copy.copy(state)
-        for i in range(0, rounds // 2):
-            ChaCha.double_round(working_state)
+        dbl_round = ChaCha.double_round
+        for _ in range(0, rounds // 2):
+            dbl_round(working_state)
 
         return [(st + wrkSt) & 0xffffffff for st, wrkSt
                 in zip(state, working_state)]

--- a/tlslite/utils/chacha.py
+++ b/tlslite/utils/chacha.py
@@ -66,18 +66,13 @@ class ChaCha(object):
         for i in range(0, rounds // 2):
             ChaCha.double_round(working_state)
 
-        for i, _ in enumerate(working_state):
-            state[i] = (state[i] + working_state[i]) & 0xffffffff
-
-        return state
+        return [(st + wrkSt) & 0xffffffff for st, wrkSt
+                in zip(state, working_state)]
 
     @staticmethod
     def word_to_bytearray(state):
         """Convert state to little endian bytestream"""
-        ret = bytearray()
-        for i in state:
-            ret += struct.pack('<L', i)
-        return ret
+        return bytearray(b"".join(struct.pack('<L', i) for i in state))
 
     @staticmethod
     def _bytearray_to_words(data):

--- a/tlslite/utils/chacha.py
+++ b/tlslite/utils/chacha.py
@@ -26,21 +26,31 @@ class ChaCha(object):
     def quarter_round(x, a, b, c, d):
         """Perform a ChaCha quarter round"""
         rotl32 = ChaCha.rotl32
-        x[a] = (x[a] + x[b]) & 0xffffffff
-        x[d] = x[d] ^ x[a]
-        x[d] = rotl32(x[d], 16)
+        xa = x[a]
+        xb = x[b]
+        xc = x[c]
+        xd = x[d]
 
-        x[c] = (x[c] + x[d]) & 0xffffffff
-        x[b] = x[b] ^ x[c]
-        x[b] = rotl32(x[b], 12)
+        xa = (xa + xb) & 0xffffffff
+        xd = xd ^ xa
+        xd = rotl32(xd, 16)
 
-        x[a] = (x[a] + x[b]) & 0xffffffff
-        x[d] = x[d] ^ x[a]
-        x[d] = rotl32(x[d], 8)
+        xc = (xc + xd) & 0xffffffff
+        xb = xb ^ xc
+        xb = rotl32(xb, 12)
 
-        x[c] = (x[c] + x[d]) & 0xffffffff
-        x[b] = x[b] ^ x[c]
-        x[b] = rotl32(x[b], 7)
+        xa = (xa + xb) & 0xffffffff
+        xd = xd ^ xa
+        xd = rotl32(xd, 8)
+
+        xc = (xc + xd) & 0xffffffff
+        xb = xb ^ xc
+        xb = rotl32(xb, 7)
+
+        x[a] = xa
+        x[b] = xb
+        x[c] = xc
+        x[d] = xd
 
     @staticmethod
     def double_round(x):

--- a/tlslite/utils/chacha.py
+++ b/tlslite/utils/chacha.py
@@ -67,11 +67,7 @@ class ChaCha(object):
     @staticmethod
     def chacha_block(key, counter, nonce, rounds):
         """Generate a state of a single block"""
-        state = []
-        state.extend(ChaCha.constants)
-        state.extend(key)
-        state.append(counter)
-        state.extend(nonce)
+        state = ChaCha.constants + key + [counter] + nonce
 
         working_state = state[:]
         dbl_round = ChaCha.double_round

--- a/tlslite/utils/chacha.py
+++ b/tlslite/utils/chacha.py
@@ -64,7 +64,7 @@ class ChaCha(object):
         state.append(counter)
         state.extend(nonce)
 
-        working_state = copy.copy(state)
+        working_state = state[:]
         dbl_round = ChaCha.double_round
         for _ in range(0, rounds // 2):
             dbl_round(working_state)

--- a/tlslite/utils/chacha.py
+++ b/tlslite/utils/chacha.py
@@ -111,7 +111,7 @@ class ChaCha(object):
     @staticmethod
     def word_to_bytearray(state):
         """Convert state to little endian bytestream"""
-        return bytearray(b"".join(struct.pack('<L', i) for i in state))
+        return bytearray(struct.pack('<LLLLLLLLLLLLLLLL', *state))
 
     @staticmethod
     def _bytearray_to_words(data):

--- a/tlslite/utils/chacha.py
+++ b/tlslite/utils/chacha.py
@@ -10,6 +10,11 @@ from __future__ import division
 from .compat import compat26Str
 import copy
 import struct
+try:
+    # in Python 3 the native zip returns iterator
+    from itertools import izip
+except ImportError:
+    izip = zip
 
 class ChaCha(object):
 
@@ -101,7 +106,7 @@ class ChaCha(object):
             dbl_round(working_state)
 
         return [(st + wrkSt) & 0xffffffff for st, wrkSt
-                in zip(state, working_state)]
+                in izip(state, working_state)]
 
     @staticmethod
     def word_to_bytearray(state):
@@ -143,7 +148,7 @@ class ChaCha(object):
                                              self.rounds)
             key_stream = ChaCha.word_to_bytearray(key_stream)
             encrypted_message += bytearray(x ^ y for x, y
-                                           in zip(key_stream, block))
+                                           in izip(key_stream, block))
 
         return encrypted_message
 

--- a/tlslite/utils/chacha.py
+++ b/tlslite/utils/chacha.py
@@ -117,8 +117,8 @@ class ChaCha(object):
                                              self.rounds)
             key_stream = ChaCha.word_to_bytearray(key_stream)
             block = plaintext[i*64:(i+1)*64]
-            encrypted_message += bytearray((x ^ y for x, y \
-                                            in zip(key_stream, block)))
+            encrypted_message += bytearray(x ^ y for x, y
+                                           in zip(key_stream, block))
 
         return encrypted_message
 

--- a/tlslite/utils/chacha.py
+++ b/tlslite/utils/chacha.py
@@ -135,17 +135,13 @@ class ChaCha(object):
     def encrypt(self, plaintext):
         """Encrypt the data"""
         encrypted_message = bytearray()
-        if len(plaintext) % 64 != 0:
-            extra = 1
-        else:
-            extra = 0
-        for i in range(0, len(plaintext) // 64 + extra):
+        for i, block in enumerate(plaintext[i:i+64] for i
+                                  in range(0, len(plaintext), 64)):
             key_stream = ChaCha.chacha_block(self.key,
                                              self.counter + i,
                                              self.nonce,
                                              self.rounds)
             key_stream = ChaCha.word_to_bytearray(key_stream)
-            block = plaintext[i*64:(i+1)*64]
             encrypted_message += bytearray(x ^ y for x, y
                                            in zip(key_stream, block))
 


### PR DESCRIPTION
Using the following microbenchmark:
```
PYTHONPATH=. python2 -m timeit -n 10000 -r 10 \
--setup "from tlslite.utils.chacha import ChaCha;
cc = ChaCha(bytearray(32), bytearray(12));
e = bytearray(b'some text for encryption with a bit more text than a single block')"\
"cc.encrypt(e)"
```
The following changes make ChaCha20 implementation 1.8 times faster compared to current `master`. 425 usec vs 231 usec per loop on my machine.
