### PR TITLE
Update ChaCha20 cipher definitions

### DIFF
--- a/tests/tlstest.py
+++ b/tests/tlstest.py
@@ -414,7 +414,7 @@ def clientTestCmd(argv):
     print("Test {0} - throughput test".format(test_no))
     for implementation in implementations:
         for cipher in ["aes128gcm", "aes256gcm", "aes128", "aes256", "3des",
-                       "rc4", "chacha20-poly1305"]:
+                       "rc4", "chacha20-poly1305_draft00"]:
             # skip tests with implementations that don't support them
             if cipher == "3des" and implementation not in ("openssl",
                                                            "pycrypto"):
@@ -423,7 +423,7 @@ def clientTestCmd(argv):
                     implementation not in ("pycrypto",
                                            "python"):
                 continue
-            if cipher in ("chacha20-poly1305", ) and \
+            if cipher in ("chacha20-poly1305_draft00", ) and \
                     implementation not in ("python", ):
                 continue
 
@@ -1039,7 +1039,7 @@ def serverTestCmd(argv):
     print("Test {0} - throughput test".format(test_no))
     for implementation in implementations:
         for cipher in ["aes128gcm", "aes256gcm", "aes128", "aes256", "3des",
-                       "rc4", "chacha20-poly1305"]:
+                       "rc4", "chacha20-poly1305_draft00"]:
             # skip tests with implementations that don't support them
             if cipher == "3des" and implementation not in ("openssl",
                                                            "pycrypto"):
@@ -1048,7 +1048,7 @@ def serverTestCmd(argv):
                     implementation not in ("pycrypto",
                                            "python"):
                 continue
-            if cipher in ("chacha20-poly1305", ) and \
+            if cipher in ("chacha20-poly1305_draft00", ) and \
                     implementation not in ("python", ):
                 continue
 

--- a/tests/tlstest.py
+++ b/tests/tlstest.py
@@ -414,7 +414,8 @@ def clientTestCmd(argv):
     print("Test {0} - throughput test".format(test_no))
     for implementation in implementations:
         for cipher in ["aes128gcm", "aes256gcm", "aes128", "aes256", "3des",
-                       "rc4", "chacha20-poly1305_draft00"]:
+                       "rc4", "chacha20-poly1305_draft00",
+                       "chacha20-poly1305"]:
             # skip tests with implementations that don't support them
             if cipher == "3des" and implementation not in ("openssl",
                                                            "pycrypto"):
@@ -423,8 +424,8 @@ def clientTestCmd(argv):
                     implementation not in ("pycrypto",
                                            "python"):
                 continue
-            if cipher in ("chacha20-poly1305_draft00", ) and \
-                    implementation not in ("python", ):
+            if cipher in ("chacha20-poly1305_draft00", "chacha20-poly1305") \
+                    and implementation not in ("python", ):
                 continue
 
             test_no += 1
@@ -1039,7 +1040,8 @@ def serverTestCmd(argv):
     print("Test {0} - throughput test".format(test_no))
     for implementation in implementations:
         for cipher in ["aes128gcm", "aes256gcm", "aes128", "aes256", "3des",
-                       "rc4", "chacha20-poly1305_draft00"]:
+                       "rc4", "chacha20-poly1305_draft00",
+                       "chacha20-poly1305"]:
             # skip tests with implementations that don't support them
             if cipher == "3des" and implementation not in ("openssl",
                                                            "pycrypto"):
@@ -1048,8 +1050,8 @@ def serverTestCmd(argv):
                     implementation not in ("pycrypto",
                                            "python"):
                 continue
-            if cipher in ("chacha20-poly1305_draft00", ) and \
-                    implementation not in ("python", ):
+            if cipher in ("chacha20-poly1305_draft00", "chacha20-poly1305") \
+                    and implementation not in ("python", ):
                 continue
 
             test_no += 1

--- a/tlslite/constants.py
+++ b/tlslite/constants.py
@@ -495,10 +495,10 @@ class CipherSuite:
 
     # draft-ietf-tls-chacha20-poly1305-00
     # ChaCha20/Poly1305 based Cipher Suites for TLS1.2
-    TLS_ECDHE_RSA_WITH_CHACHA20_POLY1305 = 0xcca1
-    ietfNames[0xcca1] = 'TLS_ECDHE_RSA_WITH_CHACHA20_POLY1305'
-    TLS_DHE_RSA_WITH_CHACHA20_POLY1305 = 0xcca3
-    ietfNames[0xcca3] = 'TLS_DHE_RSA_WITH_CHACHA20_POLY1305'
+    TLS_ECDHE_RSA_WITH_CHACHA20_POLY1305_draft_00 = 0xcca1
+    ietfNames[0xcca1] = 'TLS_ECDHE_RSA_WITH_CHACHA20_POLY1305_draft_00'
+    TLS_DHE_RSA_WITH_CHACHA20_POLY1305_draft_00 = 0xcca3
+    ietfNames[0xcca3] = 'TLS_DHE_RSA_WITH_CHACHA20_POLY1305_draft_00'
 
 
     # RFC 5289 - ECC Ciphers with SHA-256/SHA284 HMAC and AES-GCM
@@ -568,9 +568,9 @@ class CipherSuite:
     aes256GcmSuites.append(TLS_ECDHE_RSA_WITH_AES_256_GCM_SHA384)
 
     # CHACHA20 cipher (implicit POLY1305 authenticator)
-    chacha20Suites = []
-    chacha20Suites.append(TLS_ECDHE_RSA_WITH_CHACHA20_POLY1305)
-    chacha20Suites.append(TLS_DHE_RSA_WITH_CHACHA20_POLY1305)
+    chacha20draft00Suites = []
+    chacha20draft00Suites.append(TLS_ECDHE_RSA_WITH_CHACHA20_POLY1305_draft_00)
+    chacha20draft00Suites.append(TLS_DHE_RSA_WITH_CHACHA20_POLY1305_draft_00)
 
     # RC4 128 stream cipher
     rc4Suites = []
@@ -639,7 +639,7 @@ class CipherSuite:
     aeadSuites = []
     aeadSuites.extend(aes128GcmSuites)
     aeadSuites.extend(aes256GcmSuites)
-    aeadSuites.extend(chacha20Suites)
+    aeadSuites.extend(chacha20draft00Suites)
 
     # TLS1.2 with SHA384 PRF
     sha384PrfSuites = []
@@ -693,8 +693,8 @@ class CipherSuite:
             macSuites += CipherSuite.aeadSuites
 
         cipherSuites = []
-        if "chacha20-poly1305" in cipherNames and version >= (3, 3):
-            cipherSuites += CipherSuite.chacha20Suites
+        if "chacha20-poly1305_draft00" in cipherNames and version >= (3, 3):
+            cipherSuites += CipherSuite.chacha20draft00Suites
         if "aes128gcm" in cipherNames and version >= (3, 3):
             cipherSuites += CipherSuite.aes128GcmSuites
         if "aes256gcm" in cipherNames and version >= (3, 3):
@@ -780,7 +780,7 @@ class CipherSuite:
 
     # FFDHE key exchange, RSA authentication
     dheCertSuites = []
-    dheCertSuites.append(TLS_DHE_RSA_WITH_CHACHA20_POLY1305)
+    dheCertSuites.append(TLS_DHE_RSA_WITH_CHACHA20_POLY1305_draft_00)
     dheCertSuites.append(TLS_DHE_RSA_WITH_AES_256_GCM_SHA384)
     dheCertSuites.append(TLS_DHE_RSA_WITH_AES_128_GCM_SHA256)
     dheCertSuites.append(TLS_DHE_RSA_WITH_AES_256_CBC_SHA256)
@@ -796,7 +796,7 @@ class CipherSuite:
 
     # ECDHE key exchange, RSA authentication
     ecdheCertSuites = []
-    ecdheCertSuites.append(TLS_ECDHE_RSA_WITH_CHACHA20_POLY1305)
+    ecdheCertSuites.append(TLS_ECDHE_RSA_WITH_CHACHA20_POLY1305_draft_00)
     ecdheCertSuites.append(TLS_ECDHE_RSA_WITH_AES_256_GCM_SHA384)
     ecdheCertSuites.append(TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256)
     ecdheCertSuites.append(TLS_ECDHE_RSA_WITH_AES_256_CBC_SHA384)
@@ -863,8 +863,8 @@ class CipherSuite:
             return "3des"
         elif ciphersuite in CipherSuite.nullSuites:
             return "null"
-        elif ciphersuite in CipherSuite.chacha20Suites:
-            return "chacha20-poly1305"
+        elif ciphersuite in CipherSuite.chacha20draft00Suites:
+            return "chacha20-poly1305_draft00"
         else:
             return None
 

--- a/tlslite/constants.py
+++ b/tlslite/constants.py
@@ -500,6 +500,11 @@ class CipherSuite:
     TLS_DHE_RSA_WITH_CHACHA20_POLY1305_draft_00 = 0xcca3
     ietfNames[0xcca3] = 'TLS_DHE_RSA_WITH_CHACHA20_POLY1305_draft_00'
 
+    # RFC 7905 - ChaCha20-Poly1305 Cipher Suites for TLS
+    TLS_ECDHE_RSA_WITH_CHACHA20_POLY1305_SHA256 = 0xcca8
+    ietfNames[0xcca8] = 'TLS_ECDHE_RSA_WITH_CHACHA20_POLY1305_SHA256'
+    TLS_DHE_RSA_WITH_CHACHA20_POLY1305_SHA256 = 0xccaa
+    ietfNames[0xccaa] = 'TLS_DHE_RSA_WITH_CHACHA20_POLY1305_SHA256'
 
     # RFC 5289 - ECC Ciphers with SHA-256/SHA284 HMAC and AES-GCM
     TLS_ECDHE_RSA_WITH_AES_128_CBC_SHA256 = 0xC027
@@ -567,10 +572,15 @@ class CipherSuite:
     aes256GcmSuites.append(TLS_DH_ANON_WITH_AES_256_GCM_SHA384)
     aes256GcmSuites.append(TLS_ECDHE_RSA_WITH_AES_256_GCM_SHA384)
 
-    # CHACHA20 cipher (implicit POLY1305 authenticator)
+    # CHACHA20 cipher, 00'th IETF draft (implicit POLY1305 authenticator)
     chacha20draft00Suites = []
     chacha20draft00Suites.append(TLS_ECDHE_RSA_WITH_CHACHA20_POLY1305_draft_00)
     chacha20draft00Suites.append(TLS_DHE_RSA_WITH_CHACHA20_POLY1305_draft_00)
+
+    # CHACHA20 cipher (implicit POLY1305 authenticator, SHA256 PRF)
+    chacha20Suites = []
+    chacha20Suites.append(TLS_ECDHE_RSA_WITH_CHACHA20_POLY1305_SHA256)
+    chacha20Suites.append(TLS_DHE_RSA_WITH_CHACHA20_POLY1305_SHA256)
 
     # RC4 128 stream cipher
     rc4Suites = []
@@ -639,6 +649,7 @@ class CipherSuite:
     aeadSuites = []
     aeadSuites.extend(aes128GcmSuites)
     aeadSuites.extend(aes256GcmSuites)
+    aeadSuites.extend(chacha20Suites)
     aeadSuites.extend(chacha20draft00Suites)
 
     # TLS1.2 with SHA384 PRF
@@ -693,6 +704,8 @@ class CipherSuite:
             macSuites += CipherSuite.aeadSuites
 
         cipherSuites = []
+        if "chacha20-poly1305" in cipherNames and version >= (3, 3):
+            cipherSuites += CipherSuite.chacha20Suites
         if "chacha20-poly1305_draft00" in cipherNames and version >= (3, 3):
             cipherSuites += CipherSuite.chacha20draft00Suites
         if "aes128gcm" in cipherNames and version >= (3, 3):
@@ -780,6 +793,7 @@ class CipherSuite:
 
     # FFDHE key exchange, RSA authentication
     dheCertSuites = []
+    dheCertSuites.append(TLS_DHE_RSA_WITH_CHACHA20_POLY1305_SHA256)
     dheCertSuites.append(TLS_DHE_RSA_WITH_CHACHA20_POLY1305_draft_00)
     dheCertSuites.append(TLS_DHE_RSA_WITH_AES_256_GCM_SHA384)
     dheCertSuites.append(TLS_DHE_RSA_WITH_AES_128_GCM_SHA256)
@@ -796,6 +810,7 @@ class CipherSuite:
 
     # ECDHE key exchange, RSA authentication
     ecdheCertSuites = []
+    ecdheCertSuites.append(TLS_ECDHE_RSA_WITH_CHACHA20_POLY1305_SHA256)
     ecdheCertSuites.append(TLS_ECDHE_RSA_WITH_CHACHA20_POLY1305_draft_00)
     ecdheCertSuites.append(TLS_ECDHE_RSA_WITH_AES_256_GCM_SHA384)
     ecdheCertSuites.append(TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256)
@@ -865,6 +880,8 @@ class CipherSuite:
             return "null"
         elif ciphersuite in CipherSuite.chacha20draft00Suites:
             return "chacha20-poly1305_draft00"
+        elif ciphersuite in CipherSuite.chacha20Suites:
+            return "chacha20-poly1305"
         else:
             return None
 

--- a/tlslite/constants.py
+++ b/tlslite/constants.py
@@ -495,6 +495,8 @@ class CipherSuite:
 
     # draft-ietf-tls-chacha20-poly1305-00
     # ChaCha20/Poly1305 based Cipher Suites for TLS1.2
+    TLS_ECDHE_RSA_WITH_CHACHA20_POLY1305 = 0xcca1
+    ietfNames[0xcca1] = 'TLS_ECDHE_RSA_WITH_CHACHA20_POLY1305'
     TLS_DHE_RSA_WITH_CHACHA20_POLY1305 = 0xcca3
     ietfNames[0xcca3] = 'TLS_DHE_RSA_WITH_CHACHA20_POLY1305'
 
@@ -567,6 +569,7 @@ class CipherSuite:
 
     # CHACHA20 cipher (implicit POLY1305 authenticator)
     chacha20Suites = []
+    chacha20Suites.append(TLS_ECDHE_RSA_WITH_CHACHA20_POLY1305)
     chacha20Suites.append(TLS_DHE_RSA_WITH_CHACHA20_POLY1305)
 
     # RC4 128 stream cipher
@@ -793,6 +796,7 @@ class CipherSuite:
 
     # ECDHE key exchange, RSA authentication
     ecdheCertSuites = []
+    ecdheCertSuites.append(TLS_ECDHE_RSA_WITH_CHACHA20_POLY1305)
     ecdheCertSuites.append(TLS_ECDHE_RSA_WITH_AES_256_GCM_SHA384)
     ecdheCertSuites.append(TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256)
     ecdheCertSuites.append(TLS_ECDHE_RSA_WITH_AES_256_CBC_SHA384)

--- a/tlslite/handshakesettings.py
+++ b/tlslite/handshakesettings.py
@@ -12,11 +12,12 @@ from .utils import cryptomath
 from .utils import cipherfactory
 from .utils.compat import ecdsaAllCurves
 
-CIPHER_NAMES = ["chacha20-poly1305_draft00",
+CIPHER_NAMES = ["chacha20-poly1305",
                 "aes256gcm", "aes128gcm",
                 "aes256", "aes128",
                 "3des"]
-ALL_CIPHER_NAMES = CIPHER_NAMES + ["rc4", "null"]
+ALL_CIPHER_NAMES = CIPHER_NAMES + ["chacha20-poly1305_draft00",
+                                   "rc4", "null"]
 MAC_NAMES = ["sha", "sha256", "sha384", "aead"] # Don't allow "md5" by default.
 ALL_MAC_NAMES = MAC_NAMES + ["md5"]
 KEY_EXCHANGE_NAMES = ["rsa", "dhe_rsa", "ecdhe_rsa", "srp_sha", "srp_sha_rsa",

--- a/tlslite/handshakesettings.py
+++ b/tlslite/handshakesettings.py
@@ -12,7 +12,7 @@ from .utils import cryptomath
 from .utils import cipherfactory
 from .utils.compat import ecdsaAllCurves
 
-CIPHER_NAMES = ["chacha20-poly1305",
+CIPHER_NAMES = ["chacha20-poly1305_draft00",
                 "aes256gcm", "aes128gcm",
                 "aes256", "aes128",
                 "3des"]

--- a/tlslite/recordlayer.py
+++ b/tlslite/recordlayer.py
@@ -749,7 +749,7 @@ class RecordLayer(object):
             keyLength = 16
             ivLength = 4
             createCipherFunc = createAESGCM
-        elif cipherSuite in CipherSuite.chacha20Suites:
+        elif cipherSuite in CipherSuite.chacha20draft00Suites:
             keyLength = 32
             ivLength = 4
             createCipherFunc = createCHACHA20

--- a/unit_tests/test_tlslite_recordlayer.py
+++ b/unit_tests/test_tlslite_recordlayer.py
@@ -906,6 +906,69 @@ class TestRecordLayer(unittest.TestCase):
             b'\x00\x00\x00\x00\x00\x00\x00\x00\xb5c\x15\x8c' +
             b'\xe3\x92H6l\x90\x19\xef\x96\xbfT}\xe8\xbaE\xa3'))
 
+    def test_sendRecord_with_ChaCha20_draft00(self):
+        sock = MockSocket(bytearray(0))
+
+        recordLayer = RecordLayer(sock)
+        recordLayer.version = (3, 3)
+
+        ciph = CipherSuite.TLS_ECDHE_RSA_WITH_CHACHA20_POLY1305_draft_00
+        recordLayer.calcPendingStates(ciph,
+                                      bytearray(48), # master secret
+                                      bytearray(32), # client random
+                                      bytearray(32), # server random
+                                      None)
+        recordLayer.changeWriteState()
+
+        app_data = ApplicationData().create(bytearray(b'test'))
+
+        self.assertIsNotNone(app_data)
+
+        for result in recordLayer.sendRecord(app_data):
+            if result in (0, 1):
+                self.assertTrue(False, "blocking socket")
+            else: break
+
+        self.assertEqual(len(sock.sent), 1)
+        self.assertEqual(sock.sent[0][:5], bytearray(
+            b'\x17' +           # application data
+            b'\x03\x03' +       # TLSv1.2
+            b'\x00\x14'         # length
+            ))
+        self.assertEqual(sock.sent[0][5:], bytearray(
+            b'8k9<\xf3\xdc\x86d,\xf4\xb7\xe8L7\xecA\x7fi\xb1\xdc'))
+
+    def test_recvRecord_with_ChaCha20_draft00(self):
+        sock = MockSocket(bytearray(
+            b'\x17' +           # application data
+            b'\x03\x03' +       # TLSv1.2
+            b'\x00\x14' +       # length
+            b'8k9<\xf3\xdc\x86d,\xf4\xb7\xe8L7\xecA\x7fi\xb1\xdc'))
+
+        recordLayer = RecordLayer(sock)
+        recordLayer.version = (3, 3)
+        recordLayer.client = False
+
+        ciph = CipherSuite.TLS_ECDHE_RSA_WITH_CHACHA20_POLY1305_draft_00
+        recordLayer.calcPendingStates(ciph,
+                                      bytearray(48), # master secret
+                                      bytearray(32), # client random
+                                      bytearray(32), # server random
+                                      None)
+        recordLayer.changeReadState()
+
+        for result in recordLayer.recvRecord():
+            if result in (0, 1):
+                self.assertTrue(False, "blocking socket")
+            else:
+                break
+
+        head, parser = result
+
+        self.assertEqual((3, 3), head.version)
+        self.assertEqual(head.type, ContentType.application_data)
+        self.assertEqual(bytearray(b'test'), parser.bytes)
+
     # tlslite has no pure python implementation of 3DES
     @unittest.skipUnless(cryptomath.m2cryptoLoaded or cryptomath.pycryptoLoaded,
                          "requires native 3DES implementation")

--- a/unit_tests/test_tlslite_recordlayer.py
+++ b/unit_tests/test_tlslite_recordlayer.py
@@ -969,6 +969,70 @@ class TestRecordLayer(unittest.TestCase):
         self.assertEqual(head.type, ContentType.application_data)
         self.assertEqual(bytearray(b'test'), parser.bytes)
 
+    def test_sendRecord_with_ChaCha20(self):
+        sock = MockSocket(bytearray(0))
+
+        recordLayer = RecordLayer(sock)
+        recordLayer.version = (3, 3)
+
+        ciph = CipherSuite.TLS_ECDHE_RSA_WITH_CHACHA20_POLY1305_SHA256
+        recordLayer.calcPendingStates(ciph,
+                                      bytearray(48), # master secret
+                                      bytearray(32), # client random
+                                      bytearray(32), # server random
+                                      None)
+        recordLayer.changeWriteState()
+
+        app_data = ApplicationData().create(bytearray(b'test'))
+
+        self.assertIsNotNone(app_data)
+
+        for result in recordLayer.sendRecord(app_data):
+            if result in (0, 1):
+                self.assertTrue(False, "blocking socket")
+            else: break
+
+        self.assertEqual(len(sock.sent), 1)
+        self.assertEqual(sock.sent[0][:5], bytearray(
+            b'\x17' +           # application data
+            b'\x03\x03' +       # TLSv1.2
+            b'\x00\x14'         # length
+            ))
+        self.assertEqual(sock.sent[0][5:], bytearray(
+            b's\x1e\xe8(+h0\x84\xbf\x96,\xbc\xdf\\\x8c\xad=\x95\xa1\x9a'))
+
+    def test_recvRecord_with_ChaCha20(self):
+        sock = MockSocket(bytearray(
+            b'\x17' +           # application data
+            b'\x03\x03' +       # TLSv1.2
+            b'\x00\x14' +       # length
+            b's\x1e\xe8(+h0\x84\xbf\x96,\xbc\xdf\\\x8c\xad=\x95\xa1\x9a'))
+
+        recordLayer = RecordLayer(sock)
+        recordLayer.version = (3, 3)
+        recordLayer.client = False
+
+        ciph = CipherSuite.TLS_ECDHE_RSA_WITH_CHACHA20_POLY1305_SHA256
+        recordLayer.calcPendingStates(ciph,
+                                      bytearray(48), # master secret
+                                      bytearray(32), # client random
+                                      bytearray(32), # server random
+                                      None)
+        recordLayer.changeReadState()
+
+        for result in recordLayer.recvRecord():
+            if result in (0, 1):
+                self.assertTrue(False, "blocking socket")
+            else:
+                break
+
+        head, parser = result
+
+        self.assertEqual((3, 3), head.version)
+        self.assertEqual(head.type, ContentType.application_data)
+        self.assertEqual(bytearray(b'test'), parser.bytes)
+
+
     # tlslite has no pure python implementation of 3DES
     @unittest.skipUnless(cryptomath.m2cryptoLoaded or cryptomath.pycryptoLoaded,
                          "requires native 3DES implementation")


### PR DESCRIPTION
Since draft-ietf-tls-chacha20-poly1305-00 is no longer valid, we need to update the code to handle the new standard.

fixes #56
fixes #65

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/tomato42/tlslite-ng/91)
<!-- Reviewable:end -->
