### PR TITLE
define ecdhe/ecdsa aes 128/256 cbc/sha mode as per rfc 4492

### DIFF
--- a/tlslite/constants.py
+++ b/tlslite/constants.py
@@ -398,6 +398,10 @@ class CipherSuite:
     ietfNames[0x009F] = 'TLS_DHE_RSA_WITH_AES_256_GCM_SHA384'
 
     # RFC 4492 - ECC Cipher Suites for TLS
+    TLS_ECDHE_ECDSA_WITH_AES_128_CBC_SHA = 0xC009
+    ietfNames[0xC009] = 'TLS_ECDHE_ECDSA_WITH_AES_128_CBC_SHA'
+    TLS_ECDHE_ECDSA_WITH_AES_256_CBC_SHA = 0xC00A
+    ietfNames[0xC00A] = 'TLS_ECDHE_ECDSA_WITH_AES_256_CBC_SHA'
     TLS_ECDHE_RSA_WITH_NULL_SHA = 0xC010
     ietfNames[0xC010] = 'TLS_ECDHE_RSA_WITH_NULL_SHA'
     TLS_ECDHE_RSA_WITH_AES_128_CBC_SHA = 0xC013
@@ -458,6 +462,7 @@ class CipherSuite:
     aes128Suites.append(TLS_ECDHE_RSA_WITH_AES_128_CBC_SHA)
     aes128Suites.append(TLS_ECDHE_RSA_WITH_AES_128_CBC_SHA256)
     aes128Suites.append(TLS_ECDH_ANON_WITH_AES_128_CBC_SHA)
+    aes128Suites.append(TLS_ECDHE_ECDSA_WITH_AES_128_CBC_SHA)
 
     # AES-256 CBC ciphers
     aes256Suites = []
@@ -472,6 +477,7 @@ class CipherSuite:
     aes256Suites.append(TLS_ECDHE_RSA_WITH_AES_256_CBC_SHA)
     aes256Suites.append(TLS_ECDHE_RSA_WITH_AES_256_CBC_SHA384)
     aes256Suites.append(TLS_ECDH_ANON_WITH_AES_256_CBC_SHA)
+    aes256Suites.append(TLS_ECDHE_ECDSA_WITH_AES_256_CBC_SHA)
 
     # AES-128 GCM ciphers
     aes128GcmSuites = []
@@ -533,6 +539,8 @@ class CipherSuite:
     shaSuites.append(TLS_ECDH_ANON_WITH_3DES_EDE_CBC_SHA)
     shaSuites.append(TLS_ECDH_ANON_WITH_RC4_128_SHA)
     shaSuites.append(TLS_ECDH_ANON_WITH_NULL_SHA)
+    shaSuites.append(TLS_ECDHE_ECDSA_WITH_AES_128_CBC_SHA)
+    shaSuites.append(TLS_ECDHE_ECDSA_WITH_AES_256_CBC_SHA)
 
     # SHA-256 HMAC, SHA-256 PRF
     sha256Suites = []


### PR DESCRIPTION
As per commit message it would be great to include this patch and preferably even a new alpha release. As I'm using `tlslite-ng` as part of `httpreplay` which in turn is used in `Cuckoo Sandbox` - where we see quite some analyses hitting this exact issue - it would be great if we can start using a new version of `tlslite-ng` without having to monkey patch our `tlslite-ng==0.6.0a3` setup.

Thanks,
Jurriaan

<!-- Reviewable:start -->

---

This change is [<img src="https://reviewable.io/review_button.svg" height="35" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/tomato42/tlslite-ng/96)

<!-- Reviewable:end -->
