### PR TITLE
python 2.7.3 compatibility

### DIFF
--- a/tlslite/utils/compat.py
+++ b/tlslite/utils/compat.py
@@ -55,7 +55,8 @@ if sys.version_info >= (3,0):
 else:
     # Python 2.6 requires strings instead of bytearrays in a couple places,
     # so we define this function so it does the conversion if needed.
-    if sys.version_info < (2,7):
+    # same thing with very old 2.7 versions
+    if sys.version_info < (2, 7) or sys.version_info < (2, 7, 4):
         def compat26Str(x): return str(x)
     else:
         def compat26Str(x): return x


### PR DESCRIPTION
The python on Debian 7 (Wheezy) is closer to 2.6 than to 2.7,
for example struct.pack requires str() and will not accept
bytearray().

make the compat26Str() handle this old python correctly

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/tomato42/tlslite-ng/129)
<!-- Reviewable:end -->
