### PR TITLE
Sanity checking in SNI

### DIFF
--- a/scripts/tls.py
+++ b/scripts/tls.py
@@ -34,6 +34,7 @@ from tlslite.constants import CipherSuite, HashAlgorithm, SignatureAlgorithm, \
         GroupName
 from tlslite import __version__
 from tlslite.utils.compat import b2a_hex
+from tlslite.utils.dns_utils import is_valid_hostname
 
 try:
     from tack.structures.Tack import Tack
@@ -343,6 +344,9 @@ def serverCmd(argv):
     #############
     sessionCache = SessionCache()
     username = None
+    sni = None
+    if is_valid_hostname(address[0]):
+        sni = address[0]
 
     class MyHTTPServer(ThreadingMixIn, TLSSocketServerMixIn, HTTPServer):
         def handshake(self, connection):
@@ -368,7 +372,8 @@ def serverCmd(argv):
                                               settings=settings,
                                               nextProtos=[b"http/1.1"],
                                               alpn=[bytearray(b'http/1.1')],
-                                              reqCert=reqCert)
+                                              reqCert=reqCert,
+                                              sni=sni)
                                               # As an example (does not work here):
                                               #nextProtos=[b"spdy/3", b"spdy/2", b"http/1.1"])
                 stop = time.clock()

--- a/tlslite/integration/clienthelper.py
+++ b/tlslite/integration/clienthelper.py
@@ -70,6 +70,16 @@ class ClientHelper(object):
         @param settings: Various settings which can be used to control
         the ciphersuites, certificate types, and SSL/TLS versions
         offered by the client.
+
+        @type anon: bool
+        @param anon: set to True if the negotiation should advertise only
+        anonymous TLS ciphersuites. Mutually exclusive with client certificate
+        authentication or SRP authentication
+
+        @type host: str or None
+        @param host: the hostname that the connection is made to. Can be an
+        IP address (in which case the SNI extension won't be sent). Can
+        include the port (in which case the port will be stripped and ignored).
         """
 
         self.username = None

--- a/tlslite/integration/clienthelper.py
+++ b/tlslite/integration/clienthelper.py
@@ -10,6 +10,7 @@ A helper class for using TLS Lite with stdlib clients
 """
 
 from tlslite.checker import Checker
+from tlslite.utils.dns_utils import is_valid_hostname
 
 class ClientHelper(object):
     """This is a helper class used to integrate TLS Lite with various
@@ -103,8 +104,14 @@ class ClientHelper(object):
 
         self.tlsSession = None
 
-        if not self._isIP(host):
+        if host is not None and not self._isIP(host):
+            # name for SNI so port can't be sent
+            colon = host.find(':')
+            if colon > 0:
+                host = host[:colon]
             self.serverName = host
+            if host and not is_valid_hostname(host):
+                raise ValueError("Invalid hostname: {0}".format(host))
         else:
             self.serverName = None
 

--- a/tlslite/utils/dns_utils.py
+++ b/tlslite/utils/dns_utils.py
@@ -1,0 +1,41 @@
+# Copyright (c) 2017 Hubert Kario
+#
+# See the LICENSE file for legal information regarding use of this file.
+
+"""Utilities for handling DNS hostnames"""
+
+import re
+
+
+def is_valid_hostname(hostname):
+    """
+    Check if the parameter is a valid hostname.
+
+    @type hostname: str or bytearray
+    @rtype: boolean
+    """
+    try:
+        if not isinstance(hostname, str):
+            hostname = hostname.decode('ascii', 'strict')
+    except UnicodeDecodeError:
+        return False
+    if hostname[-1] == ".":
+        # strip exactly one dot from the right, if present
+        hostname = hostname[:-1]
+    # the maximum length of the domain name is 255 bytes, but because they
+    # are encoded as labels (which is a length byte and an up to 63 character
+    # ascii string), you change the dots to the length bytes, but the
+    # host element of the FQDN doesn't start with a dot and the name doesn't
+    # end with a dot (specification of a root label), we need to subtract 2
+    # bytes from the 255 byte maximum when looking at dot-deliminated FQDN
+    # with the trailing dot removed
+    # see RFC 1035
+    if len(hostname) > 253:
+        return False
+
+    # must not be all-numeric, so that it can't be confused with an ip-address
+    if re.match(r"[\d.]+$", hostname):
+        return False
+
+    allowed = re.compile(r"(?!-)[A-Z\d-]{1,63}(?<!-)$", re.IGNORECASE)
+    return all(allowed.match(x) for x in hostname.split("."))

--- a/unit_tests/test_tlslite_tlsconnection.py
+++ b/unit_tests/test_tlslite_tlsconnection.py
@@ -214,15 +214,15 @@ class TestTLSConnection(unittest.TestCase):
         conn = TLSConnection(sock)
         # create hostname extension
         with self.assertRaises(TLSRemoteAlert):
-            # use serverName with 254 bytes
+            # use serverName with 252 bytes
             conn.handshakeClientCert(
-                serverName='aaaaaaaaaabbbbbbbbbbccccccccccdddddddddd' +
-                           'eeeeeeeeeeffffffffffgggggggggghhhhhhhhhh' +
-                           'iiiiiiiiiijjjjjjjjjjkkkkkkkkkkllllllllll' +
-                           'mmmmmmmmmmnnnnnnnnnnoooooooooopppppppppp' +
-                           'qqqqqqqqqqrrrrrrrrrrsssssssssstttttttttt' +
-                           'uuuuuuuuuuvvvvvvvvvvwwwwwwwwwwxxxxxxxxxx' +
-                           'yyyyyyyyyy.com')
+                serverName='aaaaaaaaaabbbbbbbbbbccccccccccdddddddddd.' +
+                           'eeeeeeeeeeffffffffffgggggggggghhhhhhhhhh.' +
+                           'iiiiiiiiiijjjjjjjjjjkkkkkkkkkkllllllllll.' +
+                           'mmmmmmmmmmnnnnnnnnnnoooooooooopppppppppp.' +
+                           'qqqqqqqqqqrrrrrrrrrrsssssssssstttttttttt.' +
+                           'uuuuuuuuuuvvvvvvvvvvwwwwwwwwwwxxxxxxxxxx.' +
+                           'y.com')
 
         self.assertEqual(len(sock.sent), 1)
         # check for version and content type (handshake)

--- a/unit_tests/test_tlslite_utils_dns_utils.py
+++ b/unit_tests/test_tlslite_utils_dns_utils.py
@@ -1,0 +1,40 @@
+# Copyright (c) 2017, Hubert Kario
+#
+# See the LICENSE file for legal information regarding use of this file.
+
+# compatibility with Python 2.6, for that we need unittest2 package,
+# which is not available on 3.3 or 3.4
+try:
+    import unittest2 as unittest
+except ImportError:
+    import unittest
+from tlslite.utils.dns_utils import is_valid_hostname
+
+class TestIsValidHostname(unittest.TestCase):
+    def test_example(self):
+        self.assertTrue(is_valid_hostname(b'example.com'))
+
+    def test_ip(self):
+        self.assertFalse(is_valid_hostname(b'192.168.0.1'))
+
+    def test_ip_dot(self):
+        self.assertFalse(is_valid_hostname(b'192.168.0.1.'))
+
+    def test_ip_lookalike_hostname(self):
+        self.assertTrue(is_valid_hostname(b'192.168.example.com'))
+
+    def test_with_tld_dot(self):
+        self.assertTrue(is_valid_hostname(b'example.com.'))
+
+    def test_hostname_alone(self):
+        self.assertTrue(is_valid_hostname(b'localhost'))
+
+    def test_very_long_hostname(self):
+        self.assertFalse(is_valid_hostname(b'a' * 250 + b'.example.com'))
+
+    def test_very_long_host(self):
+        self.assertFalse(is_valid_hostname(b'a' * 70 + b'.example.com'))
+
+    def test_long_hostname(self):
+        self.assertTrue(is_valid_hostname(b'a' * 60 + b'.example.com'))
+


### PR DESCRIPTION
- [x] Reject invalid formatting of server_name extension (RFC compliance)
- [x] Add ability for server to compare received name to expected one

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/tomato42/tlslite-ng/148)
<!-- Reviewable:end -->
