### PR TITLE
send correct alerts in case the ALPN ext is malformed

### DIFF
--- a/tlslite/tlsconnection.py
+++ b/tlslite/tlsconnection.py
@@ -1496,10 +1496,15 @@ class TLSConnection(TLSRecordLayer):
         # Sanity check the ALPN extension
         alpnExt = clientHello.getExtension(ExtensionType.alpn)
         if alpnExt:
+            if not alpnExt.protocol_names:
+                for result in self._sendError(
+                        AlertDescription.decode_error,
+                        "Client sent empty list of ALPN names"):
+                    yield result
             for protocolName in alpnExt.protocol_names:
                 if not protocolName:
                     for result in self._sendError(
-                            AlertDescription.illegal_parameter,
+                            AlertDescription.decode_error,
                             "Client sent empty name in ALPN extension"):
                         yield result
 


### PR DESCRIPTION
since the extension is specified as:
```
   opaque ProtocolName<1..2^8-1>;

   struct {
       ProtocolName protocol_name_list<2..2^16-1>
   } ProtocolNameList;
```
empty list or empty protocol name is a protocol violation, as
such, it should cause sending a decode_error alert

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/tomato42/tlslite-ng/150)
<!-- Reviewable:end -->
