### PR TITLE
default to a common curve if no curves advertised

### DIFF
--- a/tlslite/handshakesettings.py
+++ b/tlslite/handshakesettings.py
@@ -141,6 +141,11 @@ class HandshakeSettings(object):
     @ivar requireExtendedMasterSecret: whether to require negotiation of
     extended master secret calculation for successful connection. Requires
     useExtendedMasterSecret to be set to true. False by default.
+
+    @type defaultCurve: str
+    @ivar defaultCurve: curve that will be used by server in case the client
+    did not advertise support for any curves. It does not have to be the
+    first curve for eccCurves and may be distinct from curves from that list.
     """
     def __init__(self):
         self.minKeySize = 1023
@@ -163,6 +168,7 @@ class HandshakeSettings(object):
         self.requireExtendedMasterSecret = False
         self.dhParams = None
         self.dhGroups = list(ALL_DH_GROUP_NAMES)
+        self.defaultCurve = "secp256r1"
 
     @staticmethod
     def _sanityCheckKeySizes(other):
@@ -211,6 +217,10 @@ class HandshakeSettings(object):
                         if val not in ALL_CURVE_NAMES]
         if unknownCurve:
             raise ValueError("Unknown ECC Curve name: {0}".format(unknownCurve))
+
+        if other.defaultCurve not in ALL_CURVE_NAMES:
+            raise ValueError("Unknown default ECC Curve name: {0}"
+                             .format(other.defaultCurve))
 
         unknownSigHash = [val for val in other.rsaSigHashes \
                           if val not in ALL_RSA_SIGNATURE_HASHES]
@@ -288,6 +298,7 @@ class HandshakeSettings(object):
         other.requireExtendedMasterSecret = self.requireExtendedMasterSecret
         other.dhParams = self.dhParams
         other.dhGroups = self.dhGroups
+        other.defaultCurve = self.defaultCurve
 
         if not cipherfactory.tripleDESPresent:
             other.cipherNames = [i for i in self.cipherNames if i != "3des"]

--- a/tlslite/keyexchange.py
+++ b/tlslite/keyexchange.py
@@ -468,24 +468,27 @@ class AECDHKeyExchange(KeyExchange):
 
     ECDHE without signing serverKeyExchange useful for anonymous ECDH
     """
-    def __init__(self, cipherSuite, clientHello, serverHello, acceptedCurves):
+    def __init__(self, cipherSuite, clientHello, serverHello, acceptedCurves,
+                 defaultCurve=GroupName.secp256r1):
         super(AECDHKeyExchange, self).__init__(cipherSuite, clientHello,
                                                serverHello)
         self.ecdhXs = None
         self.acceptedCurves = acceptedCurves
         self.group_id = None
         self.ecdhYc = None
+        self.defaultCurve = defaultCurve
 
     def makeServerKeyExchange(self, sigHash=None):
         """Create AECDHE version of Server Key Exchange"""
         #Get client supported groups
-        client_curves = self.clientHello.getExtension(\
+        client_curves = self.clientHello.getExtension(
                 ExtensionType.supported_groups)
         if client_curves is None:
-            # in case there is no extension, we can pick any curve, assume
-            # the most common
-            client_curves = [GroupName.secp256r1]
+            # in case there is no extension, we can pick any curve,
+            # use the configured one
+            client_curves = [self.defaultCurve]
         elif not client_curves.groups:
+            # extension should have been validated before
             raise TLSInternalError("Can't do ECDHE with no client curves")
         else:
             client_curves = client_curves.groups
@@ -554,10 +557,11 @@ class ECDHE_RSAKeyExchange(AuthenticatedKeyExchange, AECDHKeyExchange):
     """Helper class for conducting ECDHE key exchange"""
 
     def __init__(self, cipherSuite, clientHello, serverHello, privateKey,
-                 acceptedCurves):
+                 acceptedCurves, defaultCurve=GroupName.secp256r1):
         super(ECDHE_RSAKeyExchange, self).__init__(cipherSuite, clientHello,
                                                    serverHello,
-                                                   acceptedCurves)
+                                                   acceptedCurves,
+                                                   defaultCurve)
 #pylint: enable = invalid-name
         self.privateKey = privateKey
 

--- a/tlslite/tlsconnection.py
+++ b/tlslite/tlsconnection.py
@@ -1592,6 +1592,11 @@ class TLSConnection(TLSRecordLayer):
         ffGroupIntersect = True
         if clientGroups is not None:
             clientGroups = clientGroups.groups
+            if not clientGroups:
+                for result in self._sendError(
+                        AlertDescription.decode_error,
+                        "Received malformed supported_groups extension"):
+                    yield result
             serverGroups = self._curveNamesToList(settings)
             ecGroupIntersect = getFirstMatching(clientGroups, serverGroups)
             # RFC 7919 groups

--- a/tlslite/tlsconnection.py
+++ b/tlslite/tlsconnection.py
@@ -1395,11 +1395,13 @@ class TLSConnection(TLSRecordLayer):
                                                  dhGroups)
             elif cipherSuite in CipherSuite.ecdheCertSuites:
                 acceptedCurves = self._curveNamesToList(settings)
+                defaultCurve = getattr(GroupName, settings.defaultCurve)
                 keyExchange = ECDHE_RSAKeyExchange(cipherSuite,
                                                    clientHello,
                                                    serverHello,
                                                    privateKey,
-                                                   acceptedCurves)
+                                                   acceptedCurves,
+                                                   defaultCurve)
             else:
                 assert(False)
             for result in self._serverCertKeyExchange(clientHello, serverHello, 
@@ -1420,8 +1422,10 @@ class TLSConnection(TLSRecordLayer):
                                              dhGroups)
             else:
                 acceptedCurves = self._curveNamesToList(settings)
+                defaultCurve = getattr(GroupName, settings.defaultCurve)
                 keyExchange = AECDHKeyExchange(cipherSuite, clientHello,
-                                               serverHello, acceptedCurves)
+                                               serverHello, acceptedCurves,
+                                               defaultCurve)
             for result in self._serverAnonKeyExchange(serverHello, keyExchange,
                                                       cipherSuite):
                 if result in (0,1): yield result

--- a/unit_tests/test_tlslite_handshakesettings.py
+++ b/unit_tests/test_tlslite_handshakesettings.py
@@ -278,5 +278,11 @@ class TestHandshakeSettings(unittest.TestCase):
         with self.assertRaises(ValueError):
             hs.validate()
 
+    def test_invalid_defaultCurve_name(self):
+        hs = HandshakeSettings()
+        hs.defaultCurve = "ffdhe2048"
+        with self.assertRaises(ValueError):
+            hs.validate()
+
 if __name__ == '__main__':
     unittest.main()


### PR DESCRIPTION
The ECC TLS RFC states that if the client doesn't advertise
any curves, it means that it supports any and the server
can then select any curve. That was OK when there was only
one set of curves supported in TLS. Now we have the legacy
curves, brainpool curves and djb (x25519 and x448) curves,
meaning that client that doesn't advertise any curves is likely
to support only the legacy curves, not the newer ones.

Thus we need to separate the default curve from most wanted
curve as the former must be most compatible while still
relatively secure while the latter can be fastest or most
secure, but will be negotiated only when client also supports
it.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/tomato42/tlslite-ng/153)
<!-- Reviewable:end -->
