### PR TITLE
RFC7748 and RFC4492bis - X25519 and X448

### DIFF
--- a/tlslite/constants.py
+++ b/tlslite/constants.py
@@ -256,6 +256,11 @@ class GroupName(TLSEnum):
     brainpoolP512r1 = 28
     allEC.extend(list(range(26, 29)))
 
+    # draft-ietf-tls-rfc4492bis
+    x25519 = 29
+    x448 = 30
+    allEC.extend(list(range(29, 31)))
+
     # RFC7919
     ffdhe2048 = 256
     ffdhe3072 = 257

--- a/tlslite/handshakesettings.py
+++ b/tlslite/handshakesettings.py
@@ -29,7 +29,8 @@ ALL_RSA_SIGNATURE_HASHES = RSA_SIGNATURE_HASHES + ["md5"]
 RSA_SCHEMES = ["pss", "pkcs1"]
 # while secp521r1 is the most secure, it's also much slower than the others
 # so place it as the last one
-CURVE_NAMES = ["secp384r1", "secp256r1", "secp521r1"]
+CURVE_NAMES = ["x25519", "x448", "secp384r1", "secp256r1",
+               "secp521r1"]
 ALL_CURVE_NAMES = CURVE_NAMES + ["secp256k1"]
 if ecdsaAllCurves:
     ALL_CURVE_NAMES += ["secp224r1", "secp192r1"]

--- a/tlslite/keyexchange.py
+++ b/tlslite/keyexchange.py
@@ -18,8 +18,8 @@ from .utils.cryptomath import bytesToNumber, getRandomBytes, powMod, \
         numBits, numberToByteArray, divceil
 from .utils.lists import getFirstMatching
 from .utils import tlshashlib as hashlib
-from .utils.x25519 import x25519, x448, X25519_G, X448_G, X25519_ORDER, \
-        X448_ORDER
+from .utils.x25519 import x25519, x448, X25519_G, X448_G, X25519_ORDER_SIZE, \
+        X448_ORDER_SIZE
 import ecdsa
 
 class KeyExchange(object):
@@ -517,11 +517,11 @@ class AECDHKeyExchange(KeyExchange):
             if self.group_id == GroupName.x25519:
                 generator = bytearray(X25519_G)
                 fun = x25519
-                self.ecdhXs = getRandomBytes(divceil(X25519_ORDER, 8))
+                self.ecdhXs = getRandomBytes(X25519_ORDER_SIZE)
             else:
                 generator = bytearray(X448_G)
                 fun = x448
-                self.ecdhXs = getRandomBytes(divceil(X448_ORDER, 8))
+                self.ecdhXs = getRandomBytes(X448_ORDER_SIZE)
             ecdhYs = fun(self.ecdhXs, generator)
         else:
             curve = getCurveByName(GroupName.toRepr(self.group_id))
@@ -544,11 +544,11 @@ class AECDHKeyExchange(KeyExchange):
             ecdhYc = clientKeyExchange.ecdh_Yc
 
             if self.group_id == GroupName.x25519:
-                if len(ecdhYc) != 32:
+                if len(ecdhYc) != X25519_ORDER_SIZE:
                     raise TLSIllegalParameterException("Invalid key share")
                 sharedSecret = x25519(self.ecdhXs, ecdhYc)
             else:
-                if len(ecdhYc) != 56:
+                if len(ecdhYc) != X448_ORDER_SIZE:
                     raise TLSIllegalParameterException("Invalid key share")
                 sharedSecret = x448(self.ecdhXs, ecdhYc)
             self._non_zero_check(sharedSecret)
@@ -581,15 +581,15 @@ class AECDHKeyExchange(KeyExchange):
             if serverKeyExchange.named_curve == GroupName.x25519:
                 generator = bytearray(X25519_G)
                 fun = x25519
-                ecdhXc = getRandomBytes(divceil(X25519_ORDER, 8))
-                if len(serverKeyExchange.ecdh_Ys) != 32:
+                ecdhXc = getRandomBytes(X25519_ORDER_SIZE)
+                if len(serverKeyExchange.ecdh_Ys) != X25519_ORDER_SIZE:
                     raise TLSIllegalParameterException("Invalid server key "
                                                        "share")
             else:
                 generator = bytearray(X448_G)
                 fun = x448
-                ecdhXc = getRandomBytes(divceil(X448_ORDER, 8))
-                if len(serverKeyExchange.ecdh_Ys) != 56:
+                ecdhXc = getRandomBytes(X448_ORDER_SIZE)
+                if len(serverKeyExchange.ecdh_Ys) != X448_ORDER_SIZE:
                     raise TLSIllegalParameterException("Invalid server key "
                                                        "share")
             self.ecdhYc = fun(ecdhXc, generator)

--- a/tlslite/keyexchange.py
+++ b/tlslite/keyexchange.py
@@ -470,6 +470,20 @@ class AECDHKeyExchange(KeyExchange):
 
     ECDHE without signing serverKeyExchange useful for anonymous ECDH
     """
+
+    @staticmethod
+    def _non_zero_check(value):
+        """
+        Verify using constant time operation that the bytearray is not zero
+
+        @raises TLSIllegalParameterException: if the value is all zero
+        """
+        summa = 0
+        for i in value:
+            summa |= i
+        if summa == 0:
+            raise TLSIllegalParameterException("Invalid key share")
+
     def __init__(self, cipherSuite, clientHello, serverHello, acceptedCurves,
                  defaultCurve=GroupName.secp256r1):
         super(AECDHKeyExchange, self).__init__(cipherSuite, clientHello,
@@ -530,9 +544,14 @@ class AECDHKeyExchange(KeyExchange):
             ecdhYc = clientKeyExchange.ecdh_Yc
 
             if self.group_id == GroupName.x25519:
+                if len(ecdhYc) != 32:
+                    raise TLSIllegalParameterException("Invalid key share")
                 sharedSecret = x25519(self.ecdhXs, ecdhYc)
             else:
+                if len(ecdhYc) != 56:
+                    raise TLSIllegalParameterException("Invalid key share")
                 sharedSecret = x448(self.ecdhXs, ecdhYc)
+            self._non_zero_check(sharedSecret)
             return sharedSecret
         else:
             curveName = GroupName.toRepr(self.group_id)
@@ -563,12 +582,20 @@ class AECDHKeyExchange(KeyExchange):
                 generator = bytearray(X25519_G)
                 fun = x25519
                 ecdhXc = getRandomBytes(divceil(X25519_ORDER, 8))
+                if len(serverKeyExchange.ecdh_Ys) != 32:
+                    raise TLSIllegalParameterException("Invalid server key "
+                                                       "share")
             else:
                 generator = bytearray(X448_G)
                 fun = x448
                 ecdhXc = getRandomBytes(divceil(X448_ORDER, 8))
+                if len(serverKeyExchange.ecdh_Ys) != 56:
+                    raise TLSIllegalParameterException("Invalid server key "
+                                                       "share")
             self.ecdhYc = fun(ecdhXc, generator)
             S = fun(ecdhXc, serverKeyExchange.ecdh_Ys)
+            # check if the secret is not all-zero
+            self._non_zero_check(S)
             return S
         else:
             curveName = GroupName.toStr(serverKeyExchange.named_curve)

--- a/tlslite/utils/cryptomath.py
+++ b/tlslite/utils/cryptomath.py
@@ -121,13 +121,7 @@ def HKDF_expand(PRK, info, L, algorithm):
 # **************************************************************************
 
 def bytesToNumber(b):
-    total = 0
-    multiplier = 1
-    for count in range(len(b)-1, -1, -1):
-        byte = b[count]
-        total += multiplier * byte
-        multiplier *= 256
-    return total
+    return sum(i << j for i, j in zip(b, range((len(b)-1)*8, -1, -8)))
 
 def numberToByteArray(n, howManyBytes=None):
     """Convert an integer into a bytearray, zero-pad to howManyBytes.

--- a/tlslite/utils/cryptomath.py
+++ b/tlslite/utils/cryptomath.py
@@ -128,7 +128,7 @@ def bytesToNumber(b, endian="big"):
     else:
         raise ValueError("Only 'big' and 'little' endian supported")
 
-def numberToByteArray(n, howManyBytes=None):
+def numberToByteArray(n, howManyBytes=None, endian="big"):
     """
     Convert an integer into a bytearray, zero-pad to howManyBytes.
 
@@ -138,8 +138,14 @@ def numberToByteArray(n, howManyBytes=None):
     """
     if howManyBytes == None:
         howManyBytes = numBytes(n)
-    return bytearray((n >> i) & 0xff
-                     for i in range((howManyBytes-1)*8, -1, -8))
+    if endian == "big":
+        return bytearray((n >> i) & 0xff
+                         for i in range((howManyBytes-1)*8, -1, -8))
+    elif endian == "little":
+        return bytearray((n >> i) & 0xff
+                         for i in range(0, howManyBytes*8, 8))
+    else:
+        raise ValueError("Only 'big' and 'little' endian supported")
 
 def mpiToNumber(mpi): #mpi is an openssl-format bignum string
     if (ord(mpi[4]) & 0x80) !=0: #Make sure this is a positive number

--- a/tlslite/utils/cryptomath.py
+++ b/tlslite/utils/cryptomath.py
@@ -15,7 +15,7 @@ import base64
 import binascii
 import sys
 
-from .compat import compat26Str, compatHMAC, compatLong
+from .compat import compat26Str, compatHMAC, compatLong, b2a_hex
 
 
 # **************************************************************************
@@ -122,9 +122,9 @@ def HKDF_expand(PRK, info, L, algorithm):
 
 def bytesToNumber(b, endian="big"):
     if endian == "big":
-        return sum(i << j for i, j in zip(b, range((len(b)-1)*8, -1, -8)))
+        return int(b2a_hex(b), 16)
     elif endian == "little":
-        return sum(i << j for i, j in zip(b, range(0, len(b)*8, 8)))
+        return int(b2a_hex(b[::-1]), 16)
     else:
         raise ValueError("Only 'big' and 'little' endian supported")
 

--- a/tlslite/utils/cryptomath.py
+++ b/tlslite/utils/cryptomath.py
@@ -120,8 +120,13 @@ def HKDF_expand(PRK, info, L, algorithm):
 # Converter Functions
 # **************************************************************************
 
-def bytesToNumber(b):
-    return sum(i << j for i, j in zip(b, range((len(b)-1)*8, -1, -8)))
+def bytesToNumber(b, endian="big"):
+    if endian == "big":
+        return sum(i << j for i, j in zip(b, range((len(b)-1)*8, -1, -8)))
+    elif endian == "little":
+        return sum(i << j for i, j in zip(b, range(0, len(b)*8, 8)))
+    else:
+        raise ValueError("Only 'big' and 'little' endian supported")
 
 def numberToByteArray(n, howManyBytes=None):
     """Convert an integer into a bytearray, zero-pad to howManyBytes.

--- a/tlslite/utils/cryptomath.py
+++ b/tlslite/utils/cryptomath.py
@@ -129,19 +129,17 @@ def bytesToNumber(b, endian="big"):
         raise ValueError("Only 'big' and 'little' endian supported")
 
 def numberToByteArray(n, howManyBytes=None):
-    """Convert an integer into a bytearray, zero-pad to howManyBytes.
+    """
+    Convert an integer into a bytearray, zero-pad to howManyBytes.
 
     The returned bytearray may be smaller than howManyBytes, but will
     not be larger.  The returned bytearray will contain a big-endian
     encoding of the input integer (n).
-    """    
+    """
     if howManyBytes == None:
         howManyBytes = numBytes(n)
-    b = bytearray(howManyBytes)
-    for count in range(howManyBytes-1, -1, -1):
-        b[count] = int(n % 256)
-        n >>= 8
-    return b
+    return bytearray((n >> i) & 0xff
+                     for i in range((howManyBytes-1)*8, -1, -8))
 
 def mpiToNumber(mpi): #mpi is an openssl-format bignum string
     if (ord(mpi[4]) & 0x80) !=0: #Make sure this is a positive number

--- a/tlslite/utils/cryptomath.py
+++ b/tlslite/utils/cryptomath.py
@@ -140,7 +140,7 @@ def numberToByteArray(n, howManyBytes=None, endian="big"):
         howManyBytes = numBytes(n)
     if endian == "big":
         return bytearray((n >> i) & 0xff
-                         for i in range((howManyBytes-1)*8, -1, -8))
+                         for i in reversed(range(0, howManyBytes*8, 8)))
     elif endian == "little":
         return bytearray((n >> i) & 0xff
                          for i in range(0, howManyBytes*8, 8))

--- a/tlslite/utils/cryptomath.py
+++ b/tlslite/utils/cryptomath.py
@@ -133,8 +133,8 @@ def numberToByteArray(n, howManyBytes=None, endian="big"):
     Convert an integer into a bytearray, zero-pad to howManyBytes.
 
     The returned bytearray may be smaller than howManyBytes, but will
-    not be larger.  The returned bytearray will contain a big-endian
-    encoding of the input integer (n).
+    not be larger.  The returned bytearray will contain a big- or little-endian
+    encoding of the input integer (n). Big endian encoding is used by default.
     """
     if howManyBytes == None:
         howManyBytes = numBytes(n)

--- a/tlslite/utils/x25519.py
+++ b/tlslite/utils/x25519.py
@@ -43,6 +43,12 @@ def cswap(swap, x_2, x_3):
         return x_2, x_3
 
 
+X25519_G = numberToByteArray(9, 32, endian="little")
+
+
+X25519_ORDER = 256
+
+
 def x25519(k, u):
     """
     Perform point multiplication on X25519 curve.
@@ -63,6 +69,12 @@ def x25519(k, u):
     p = 2**255 - 19
 
     return _x25519_generic(k, u, bits, a24, p)
+
+
+X448_G = numberToByteArray(5, 56, endian="little")
+
+
+X448_ORDER = 448
 
 
 def x448(k, u):

--- a/tlslite/utils/x25519.py
+++ b/tlslite/utils/x25519.py
@@ -1,0 +1,124 @@
+# Authors:
+#   Hubert Kario (2017)
+#
+# See the LICENSE file for legal information regarding use of this file.
+
+"""Handling X25519 and X448 curve based key agreement protocol."""
+
+from .cryptomath import bytesToNumber, numberToByteArray, divceil
+# the names of the variables come directly from RFC 7748 so changing them
+# would make the code harder to audit/compare
+# pylint: disable=invalid-name
+
+
+def decodeUCoordinate(u, bits):
+    """Function to decode the public U coordinate of X25519-family curves."""
+    if bits not in (255, 448):
+        raise ValueError("Invalid number of expected bits")
+    if bits % 8:
+        u[-1] &= (1 << (bits % 8)) - 1
+    return bytesToNumber(u, endian="little")
+
+
+def decodeScalar22519(k):
+    """Function to decode the private K parameter of the x25519 function."""
+    k[0] &= 248
+    k[31] &= 127
+    k[31] |= 64
+    return bytesToNumber(k, endian="little")
+
+
+def decodeScalar448(k):
+    """Function to decode the private K parameter of the X448 function."""
+    k[0] &= 252
+    k[55] |= 128
+    return bytesToNumber(k, endian="little")
+
+
+def cswap(swap, x_2, x_3):
+    """Conditional swap function."""
+    if swap:
+        return x_3, x_2
+    else:
+        return x_2, x_3
+
+
+def x25519(k, u):
+    """
+    Perform point multiplication on X25519 curve.
+
+    @type k: bytearray
+    @param k: random secret value (multiplier), should be 32 byte long
+
+    @type u: bytearray
+    @param u: curve generator or the other party key share
+
+    @rtype: bytearray
+    """
+    bits = 255
+    k = decodeScalar22519(k)
+    u = decodeUCoordinate(u, bits)
+
+    a24 = 121665
+    p = 2**255 - 19
+
+    return _x25519_generic(k, u, bits, a24, p)
+
+
+def x448(k, u):
+    """
+    Perform point multiplication on X448 curve.
+
+    @type k: bytearray
+    @param k: random secret value (multiplier), should be 56 bytes long
+
+    @type u: bytearray
+    @param u: curve generator or the other party key share
+
+    @rtype: bytearray
+    """
+    bits = 448
+    k = decodeScalar448(k)
+    u = decodeUCoordinate(u, bits)
+
+    a24 = 39081
+    p = 2**448 - 2**224 - 1
+
+    return _x25519_generic(k, u, bits, a24, p)
+
+
+def _x25519_generic(k, u, bits, a24, p):
+    """Generic Montgomery ladder implementation of the x25519 algorithm."""
+    x_1 = u
+    x_2 = 1
+    z_2 = 0
+    x_3 = u
+    z_3 = 1
+    swap = 0
+
+    for t in range(bits-1, -1, -1):
+        k_t = (k >> t) & 1
+        swap ^= k_t
+        x_2, x_3 = cswap(swap, x_2, x_3)
+        z_2, z_3 = cswap(swap, z_2, z_3)
+        swap = k_t
+
+        A = (x_2 + z_2) % p
+        AA = pow(A, 2, p)
+        B = (x_2 - z_2) % p
+        BB = pow(B, 2, p)
+        E = (AA - BB) % p
+        C = (x_3 + z_3) % p
+        D = (x_3 - z_3) % p
+        DA = (D * A) % p
+        CB = (C * B) % p
+        x_3 = pow(DA + CB, 2, p)
+        z_3 = (x_1 * pow(DA - CB, 2, p)) % p
+        x_2 = (AA * BB) % p
+        z_2 = (E * (AA + a24 * E)) % p
+
+    x_2, x_3 = cswap(swap, x_2, x_3)
+    z_2, z_3 = cswap(swap, z_2, z_3)
+    ret = (x_2 * pow(z_2, p - 2, p)) % p
+    return numberToByteArray(ret, divceil(bits, 8), endian="little")
+# pylint: enable=invalid-name

--- a/tlslite/utils/x25519.py
+++ b/tlslite/utils/x25519.py
@@ -46,7 +46,7 @@ def cswap(swap, x_2, x_3):
 X25519_G = numberToByteArray(9, 32, endian="little")
 
 
-X25519_ORDER = 256
+X25519_ORDER_SIZE = 32
 
 
 def x25519(k, u):
@@ -74,7 +74,7 @@ def x25519(k, u):
 X448_G = numberToByteArray(5, 56, endian="little")
 
 
-X448_ORDER = 448
+X448_ORDER_SIZE = 56
 
 
 def x448(k, u):

--- a/unit_tests/test_tlslite_keyexchange.py
+++ b/unit_tests/test_tlslite_keyexchange.py
@@ -45,6 +45,7 @@ except ImportError:
 
 from tlslite.keyexchange import KeyExchange, RSAKeyExchange, \
         DHE_RSAKeyExchange, SRPKeyExchange, ECDHE_RSAKeyExchange
+from tlslite.utils.x25519 import x25519, X25519_G, x448, X448_G
 
 srv_raw_key = str(
     "-----BEGIN RSA PRIVATE KEY-----\n"\
@@ -1290,6 +1291,7 @@ class TestECDHE_RSAKeyExchange(unittest.TestCase):
         with self.assertRaises(TLSIllegalParameterException):
             client_keyExchange.processServerKeyExchange(None, srv_key_ex)
 
+
 class TestRSAKeyExchange_with_PSS_scheme(unittest.TestCase):
     def setUp(self):
         self.srv_private_key = parsePEMKey(srv_raw_key, private=True)
@@ -1356,3 +1358,137 @@ class TestRSAKeyExchange_with_PSS_scheme(unittest.TestCase):
                                        b"\x03\xe5[\xf5\xc7z\x02\'/\x0f\xdc\x1f"
                                        b"\xd2\x93\x8b\x12\x01%\x1d\x04\xf1["
                                        b"\xe4\x9a\x83\xf8\xd3#+"))
+
+
+class TestECDHE_RSAKeyExchange_with_x25519(unittest.TestCase):
+    def setUp(self):
+        self.srv_private_key = parsePEMKey(srv_raw_key, private=True)
+        srv_chain = X509CertChain([X509().parse(srv_raw_certificate)])
+        self.srv_pub_key = srv_chain.getEndEntityPublicKey()
+        self.cipher_suite = CipherSuite.TLS_ECDHE_RSA_WITH_AES_128_CBC_SHA
+        ext = [SupportedGroupsExtension().create([GroupName.x25519])]
+        self.client_hello = ClientHello().create((3, 3),
+                                                 bytearray(32),
+                                                 bytearray(0),
+                                                 [],
+                                                 extensions=ext)
+        self.server_hello = ServerHello().create((3, 3),
+                                                 bytearray(32),
+                                                 bytearray(0),
+                                                 self.cipher_suite)
+
+        self.keyExchange = ECDHE_RSAKeyExchange(self.cipher_suite,
+                                                self.client_hello,
+                                                self.server_hello,
+                                                self.srv_private_key,
+                                                [GroupName.x25519])
+
+    def test_ECDHE_key_exchange(self):
+        srv_key_ex = self.keyExchange.makeServerKeyExchange('sha1')
+
+        KeyExchange.verifyServerKeyExchange(srv_key_ex,
+                                            self.srv_pub_key,
+                                            self.client_hello.random,
+                                            self.server_hello.random,
+                                            [(HashAlgorithm.sha1,
+                                              SignatureAlgorithm.rsa)])
+
+        self.assertEqual(srv_key_ex.named_curve, GroupName.x25519)
+        generator = bytearray(X25519_G)
+        cln_Xc = getRandomBytes(32)
+        cln_Ys = srv_key_ex.ecdh_Ys
+        cln_Yc = x25519(cln_Xc, generator)
+
+        cln_key_ex = ClientKeyExchange(self.cipher_suite, (3, 3))
+        cln_key_ex.createECDH(cln_Yc)
+
+        cln_S = x25519(cln_Xc, cln_Ys)
+
+        srv_premaster = self.keyExchange.processClientKeyExchange(cln_key_ex)
+
+        self.assertEqual(cln_S, srv_premaster)
+
+    def test_client_ECDHE_key_exchange(self):
+        srv_key_ex = self.keyExchange.makeServerKeyExchange('sha1')
+
+        client_keyExchange = ECDHE_RSAKeyExchange(self.cipher_suite,
+                                                  self.client_hello,
+                                                  self.server_hello,
+                                                  None,
+                                                  [GroupName.x25519])
+        client_premaster = client_keyExchange.processServerKeyExchange(\
+                None,
+                srv_key_ex)
+        clientKeyExchange = client_keyExchange.makeClientKeyExchange()
+
+        server_premaster = self.keyExchange.processClientKeyExchange(\
+                clientKeyExchange)
+
+        self.assertEqual(client_premaster, server_premaster)
+
+
+class TestECDHE_RSAKeyExchange_with_x448(unittest.TestCase):
+    def setUp(self):
+        self.srv_private_key = parsePEMKey(srv_raw_key, private=True)
+        srv_chain = X509CertChain([X509().parse(srv_raw_certificate)])
+        self.srv_pub_key = srv_chain.getEndEntityPublicKey()
+        self.cipher_suite = CipherSuite.TLS_ECDHE_RSA_WITH_AES_128_CBC_SHA
+        ext = [SupportedGroupsExtension().create([GroupName.x448])]
+        self.client_hello = ClientHello().create((3, 3),
+                                                 bytearray(32),
+                                                 bytearray(0),
+                                                 [],
+                                                 extensions=ext)
+        self.server_hello = ServerHello().create((3, 3),
+                                                 bytearray(32),
+                                                 bytearray(0),
+                                                 self.cipher_suite)
+
+        self.keyExchange = ECDHE_RSAKeyExchange(self.cipher_suite,
+                                                self.client_hello,
+                                                self.server_hello,
+                                                self.srv_private_key,
+                                                [GroupName.x448])
+
+    def test_ECDHE_key_exchange(self):
+        srv_key_ex = self.keyExchange.makeServerKeyExchange('sha1')
+
+        KeyExchange.verifyServerKeyExchange(srv_key_ex,
+                                            self.srv_pub_key,
+                                            self.client_hello.random,
+                                            self.server_hello.random,
+                                            [(HashAlgorithm.sha1,
+                                              SignatureAlgorithm.rsa)])
+
+        self.assertEqual(srv_key_ex.named_curve, GroupName.x448)
+        generator = bytearray(X448_G)
+        cln_Xc = getRandomBytes(56)
+        cln_Ys = srv_key_ex.ecdh_Ys
+        cln_Yc = x448(cln_Xc, generator)
+
+        cln_key_ex = ClientKeyExchange(self.cipher_suite, (3, 3))
+        cln_key_ex.createECDH(cln_Yc)
+
+        cln_S = x448(cln_Xc, cln_Ys)
+
+        srv_premaster = self.keyExchange.processClientKeyExchange(cln_key_ex)
+
+        self.assertEqual(cln_S, srv_premaster)
+
+    def test_client_ECDHE_key_exchange(self):
+        srv_key_ex = self.keyExchange.makeServerKeyExchange('sha1')
+
+        client_keyExchange = ECDHE_RSAKeyExchange(self.cipher_suite,
+                                                  self.client_hello,
+                                                  self.server_hello,
+                                                  None,
+                                                  [GroupName.x448])
+        client_premaster = client_keyExchange.processServerKeyExchange(\
+                None,
+                srv_key_ex)
+        clientKeyExchange = client_keyExchange.makeClientKeyExchange()
+
+        server_premaster = self.keyExchange.processClientKeyExchange(\
+                clientKeyExchange)
+
+        self.assertEqual(client_premaster, server_premaster)

--- a/unit_tests/test_tlslite_utils_cryptomath.py
+++ b/unit_tests/test_tlslite_utils_cryptomath.py
@@ -126,6 +126,34 @@ class TestNumberToBytesFunctions(unittest.TestCase):
         self.assertEqual(numberToByteArray((1<<128)-1),
                          bytearray(b'\xff'*16))
 
+    @given(integers(min_value=0, max_value=0xff))
+    @example(0)
+    @example(0xff)
+    def test_small_number_little_endian(self, number):
+        self.assertEqual(numberToByteArray(number, 1, endian="little"),
+                         bytearray(struct.pack("<B", number)))
+
+    @given(integers(min_value=0, max_value=0xffffffff))
+    @example(0xffffffff)
+    def test_big_number(self, number):
+        self.assertEqual(numberToByteArray(number, 4, endian="little"),
+                         bytearray(struct.pack("<L", number)))
+
+    def test_very_large_number(self):
+        self.assertEqual(numberToByteArray((1<<128)-1, endian="little"),
+                         bytearray(b'\xff'*16))
+
+    def test_numberToByteArray_with_not_enough_length_little_endian(self):
+        self.assertEqual(numberToByteArray(0x0a0b0c, 2, endian="little"),
+                         bytearray(b'\x0c\x0b'))
+
+    def test_with_large_number_of_bytes_in_little_endian(self):
+        self.assertEqual(numberToByteArray(1, 16, endian="little"),
+                         bytearray(b'\x01' + b'\x00'*15))
+
+    def test_with_bad_endian_type(self):
+        with self.assertRaises(ValueError):
+            numberToByteArray(1, endian="middle")
 
 class TestNumBits(unittest.TestCase):
 

--- a/unit_tests/test_tlslite_utils_cryptomath.py
+++ b/unit_tests/test_tlslite_utils_cryptomath.py
@@ -109,6 +109,24 @@ class TestNumberToBytesFunctions(unittest.TestCase):
         self.assertEqual(numberToByteArray(0x0a0b0c, 2),
                          bytearray(b'\x0b\x0c'))
 
+    @given(integers(min_value=0, max_value=0xff))
+    @example(0)
+    @example(0xff)
+    def test_small_number(self, number):
+        self.assertEqual(numberToByteArray(number, 1),
+                         bytearray(struct.pack(">B", number)))
+
+    @given(integers(min_value=0, max_value=0xffffffff))
+    @example(0xffffffff)
+    def test_big_number(self, number):
+        self.assertEqual(numberToByteArray(number, 4),
+                         bytearray(struct.pack(">L", number)))
+
+    def test_very_large_number(self):
+        self.assertEqual(numberToByteArray((1<<128)-1),
+                         bytearray(b'\xff'*16))
+
+
 class TestNumBits(unittest.TestCase):
 
     @staticmethod

--- a/unit_tests/test_tlslite_utils_x25519.py
+++ b/unit_tests/test_tlslite_utils_x25519.py
@@ -1,0 +1,237 @@
+# Copyright (c) 2017, Hubert Kario
+#
+# See the LICENSE file for legal information regarding use of this file.
+
+# compatibility with Python 2.6, for that we need unittest2 package,
+# which is not available on 3.3 or 3.4
+try:
+    import unittest2 as unittest
+except ImportError:
+    import unittest
+try:
+    import mock
+    from mock import call
+except ImportError:
+    import unittest.mock as mock
+    from unittest.mock import call
+
+from tlslite.utils.x25519 import decodeUCoordinate, decodeScalar22519, \
+        decodeScalar448, x25519, x448
+from tlslite.utils.compat import a2b_hex
+
+class TestDecodeUCoordinate(unittest.TestCase):
+    def test_x25519_decode(self):
+        value = a2b_hex('e6db6867583030db3594c1a424b15f7c7'
+                        '26624ec26b3353b10a903a6d0ab1c4c')
+
+        scalar = decodeUCoordinate(value, 255)
+
+        self.assertEqual(scalar, int("344264340339195944511551077811888216513"
+                                     "16167215306631574996226621102155684838"))
+
+
+    def test_u_decode_with_invalid_bits(self):
+        v = a2b_hex('e6db6867583030db3594c1a424b15f7c7'
+                    '26624ec26b3353b10a903a6d0ab1c4c')
+        with self.assertRaises(ValueError):
+            decodeUCoordinate(v, 256)
+
+
+    def test_x448_decode(self):
+        value = a2b_hex('06fce640fa3487bfda5f6cf2d5263f8'
+                        'aad88334cbd07437f020f08f9'
+                        '814dc031ddbdc38c19c6da2583fa542'
+                        '9db94ada18aa7a7fb4ef8a086')
+
+        scalar = decodeUCoordinate(value, 448)
+
+        self.assertEqual(scalar, int("38223991081410733011622996123"
+                                     "4899377031416365"
+                                     "24057132514834655592243802516"
+                                     "2094455820962429"
+                                     "14297133958436003433731007979"
+                                     "1515452463053830"))
+
+
+    def test_x25519_decode_scalar(self):
+        value = a2b_hex('a546e36bf0527c9d3b16154b82465edd6'
+                        '2144c0ac1fc5a18506a2244ba449ac4')
+
+        scalar = decodeScalar22519(value)
+
+        self.assertEqual(scalar, int("310298424921150409048955604518630896564"
+                                     "72772604678260265531221036453811406496"))
+
+
+    def test_x448_decode_scalar(self):
+        value = a2b_hex('3d262fddf9ec8e88495266fea19a34d2'
+                        '8882acef045104d0d1aae121'
+                        '700a779c984c24f8cdd78fbff44943eb'
+                        'a368f54b29259a4f1c600ad3')
+
+        scalar = decodeScalar448(value)
+
+        self.assertEqual(int("599189175373896402783756016145213256157230856"
+                             "085026129926891459468622403380588640249457727"
+                             "683869421921443004045221642549886377526240828"),
+                         scalar)
+
+
+    # RFC 7748 Section 5.2, vector #1
+    def test_x25519_1(self):
+        k = a2b_hex("a546e36bf0527c9d3b16154b82465ed"
+                    "d62144c0ac1fc5a18506a2244ba449ac4")
+        u = a2b_hex("e6db6867583030db3594c1a424b15f7"
+                    "c726624ec26b3353b10a903a6d0ab1c4c")
+
+        ret = x25519(k, u)
+
+        self.assertEqual(a2b_hex("c3da55379de9c6908e94ea4df28d084f"
+                                 "32eccf03491c71f754b4075577a28552"),
+                         ret)
+
+
+    # RFC 7748 Section 5.2, vector #2
+    def test_x25519_2(self):
+        k = a2b_hex("4b66e9d4d1b4673c5ad22691957d6af"
+                    "5c11b6421e0ea01d42ca4169e7918ba0d")
+        u = a2b_hex("e5210f12786811d3f4b7959d0538ae2"
+                    "c31dbe7106fc03c3efc4cd549c715a493")
+
+        ret = x25519(k, u)
+
+        self.assertEqual(ret,
+                         a2b_hex("95cbde9476e8907d7aade45cb4b873f88"
+                                 "b595a68799fa152e6f8f7647aac7957"))
+
+
+    # RFC 7748 Section 5.2, vector #3
+    def test_x448_1(self):
+        k = a2b_hex("3d262fddf9ec8e88495266fea19a34d"
+                    "28882acef045104d0d1aae121"
+                    "700a779c984c24f8cdd78fbff44943e"
+                    "ba368f54b29259a4f1c600ad3")
+        u = a2b_hex("06fce640fa3487bfda5f6cf2d5263f8"
+                    "aad88334cbd07437f020f08f9"
+                    "814dc031ddbdc38c19c6da2583fa542"
+                    "9db94ada18aa7a7fb4ef8a086")
+
+        ret = x448(k, u)
+
+        self.assertEqual(ret,
+                         a2b_hex("ce3e4ff95a60dc6697da1db1d85e6afbd"
+                                 "f79b50a2412d7546d5f239f"
+                                 "e14fbaadeb445fc66a01b0779d9822396"
+                                 "1111e21766282f73dd96b6f"))
+
+
+    # RFC 7748 Section 5.2, vector #4
+    def test_x448_2(self):
+        k = a2b_hex("203d494428b8399352665ddca42f9de"
+                    "8fef600908e0d461cb021f8c5"
+                    "38345dd77c3e4806e25f46d3315c44e"
+                    "0a5b4371282dd2c8d5be3095f")
+        u = a2b_hex("0fbcc2f993cd56d3305b0b7d9e55d4c"
+                    "1a8fb5dbb52f8e9a1e9b6201b"
+                    "165d015894e56c4d3570bee52fe205e"
+                    "28a78b91cdfbde71ce8d157db")
+
+        ret = x448(k, u)
+
+        self.assertEqual(ret,
+                         a2b_hex("884a02576239ff7a2f2f63b2db6a9ff37"
+                                 "047ac13568e1e30fe63c4a7"
+                                 "ad1b3ee3a5700df34321d62077e63633c"
+                                 "575c1c954514e99da7c179d"))
+
+
+    def test_x25519_one_iteration(self):
+        k = a2b_hex("0900000000000000000000000000000"
+                    "000000000000000000000000000000000")
+        u = bytearray(k)
+
+        ret = x25519(k, u)
+
+        self.assertEqual(ret,
+                         a2b_hex("422c8e7a6227d7bca1350b3e2bb7279f7"
+                                 "897b87bb6854b783c60e80311ae3079"))
+
+
+    @unittest.skip("slow test case")
+    def test_x25519_thousand_iterations(self):
+        k = a2b_hex("0900000000000000000000000000000"
+                    "000000000000000000000000000000000")
+        u = bytearray(k)
+
+        for _ in range(1000):
+            u, k = bytearray(k), x25519(k, u)
+
+        self.assertEqual(k,
+                         a2b_hex("684cf59ba83309552800ef566f2f4d3c"
+                                 "1c3887c49360e3875f2eb94d99532c51"))
+
+
+    @unittest.skip("very slow test case")
+    def test_x25519_million_iterations(self):
+        k = a2b_hex("0900000000000000000000000000000"
+                    "000000000000000000000000000000000")
+        u = bytearray(k)
+
+        for _ in range(1000000):
+            u, k = bytearray(k), x25519(k, u)
+
+        self.assertEqual(k,
+                         a2b_hex("7c3911e0ab2586fd864497297e575e6f3b"
+                                 "c601c0883c30df5f4dd2d24f665424"))
+
+
+    def test_x448_one_iteration(self):
+        k = a2b_hex("05000000000000000000000000000000000000000"
+                    "000000000000000"
+                    "00000000000000000000000000000000000000000"
+                    "000000000000000")
+        u = bytearray(k)
+
+        ret = x448(k, u)
+
+        self.assertEqual(ret,
+                         a2b_hex("3f482c8a9f19b01e6c46ee9711d9dc14fd"
+                                 "4bf67af30765c2ae2b846a"
+                                 "4d23a8cd0db897086239492caf350b51f8"
+                                 "33868b9bc2b3bca9cf4113"))
+
+
+    @unittest.skip("slow test case")
+    def test_x448_thousand_iterations(self):
+        k = a2b_hex("05000000000000000000000000000000000000000"
+                    "000000000000000"
+                    "00000000000000000000000000000000000000000"
+                    "000000000000000")
+        u = bytearray(k)
+
+        for _ in range(1000):
+            u, k = bytearray(k), x448(k, u)
+
+        self.assertEqual(k,
+                         a2b_hex("aa3b4749d55b9daf1e5b00288826c46727"
+                                 "4ce3ebbdd5c17b975e09d4"
+                                 "af6c67cf10d087202db88286e2b79fceea"
+                                 "3ec353ef54faa26e219f38"))
+
+
+    @unittest.skip("very slow test case")
+    def test_x448_million_iterations(self):
+        k = a2b_hex("05000000000000000000000000000000000000000"
+                    "000000000000000"
+                    "00000000000000000000000000000000000000000"
+                    "000000000000000")
+        u = bytearray(k)
+
+        for _ in range(1000000):
+            u, k = bytearray(k), x448(k, u)
+
+        self.assertEqual(k,
+                         a2b_hex("077f453681caca3693198420bbe515cae"
+                                 "0002472519b3e67661a7e89"
+                                 "cab94695c8f4bcd66e61b9b9c946da8d5"
+                                 "24de3d69bd9d9d66b997e37"))

--- a/unit_tests/test_tlslite_utils_x25519.py
+++ b/unit_tests/test_tlslite_utils_x25519.py
@@ -16,8 +16,9 @@ except ImportError:
     from unittest.mock import call
 
 from tlslite.utils.x25519 import decodeUCoordinate, decodeScalar22519, \
-        decodeScalar448, x25519, x448
+        decodeScalar448, x25519, x448, X25519_G, X448_G
 from tlslite.utils.compat import a2b_hex
+from tlslite.utils.cryptomath import numberToByteArray
 
 class TestDecodeUCoordinate(unittest.TestCase):
     def test_x25519_decode(self):
@@ -235,3 +236,92 @@ class TestDecodeUCoordinate(unittest.TestCase):
                                  "0002472519b3e67661a7e89"
                                  "cab94695c8f4bcd66e61b9b9c946da8d5"
                                  "24de3d69bd9d9d66b997e37"))
+
+
+    # RFC 7748, section 6.1
+    def test_x25519_ecdh_a_share(self):
+        a_random = a2b_hex("77076d0a7318a57d3c16c17251b26645df4"
+                           "c2f87ebc0992ab177fba51db92c2a")
+        a_public = x25519(a_random, bytearray(X25519_G))
+
+        self.assertEqual(a_public,
+                         a2b_hex("8520f0098930a754748b7ddcb43ef75a0"
+                                 "dbf3a0d26381af4eba4a98eaa9b4e6a"))
+
+    def test_x25519_ecdh_b_share(self):
+        b_random = a2b_hex("5dab087e624a8a4b79e17f8b83800ee6"
+                           "6f3bb1292618b6fd1c2f8b27ff88e0eb")
+        b_public = x25519(b_random, bytearray(X25519_G))
+
+        self.assertEqual(b_public,
+                         a2b_hex("de9edb7d7b7dc1b4d35b61c2ece43537"
+                                 "3f8343c85b78674dadfc7e146f882b4f"))
+
+    def test_x25519_ecdh_shared(self):
+        a_random = a2b_hex("77076d0a7318a57d3c16c17251b26645df4"
+                           "c2f87ebc0992ab177fba51db92c2a")
+        a_public = x25519(a_random, bytearray(X25519_G))
+
+        b_random = a2b_hex("5dab087e624a8a4b79e17f8b83800ee6"
+                           "6f3bb1292618b6fd1c2f8b27ff88e0eb")
+        b_public = x25519(b_random, bytearray(X25519_G))
+
+        a_shared = x25519(a_random, b_public)
+
+        b_shared = x25519(b_random, a_public)
+
+        self.assertEqual(a_shared, b_shared)
+        self.assertEqual(a_shared,
+                         a2b_hex("4a5d9d5ba4ce2de1728e3bf480350f25"
+                                 "e07e21c947d19e3376f09b3c1e161742"))
+
+
+    # RFC 7748, section 6.2
+    def test_x448_ecdh_a_share(self):
+        a_random = a2b_hex("9a8f4925d1519f5775cf46b04b58"
+                           "00d4ee9ee8bae8bc5565d498c28d"
+                           "d9c9baf574a94197448973910063"
+                           "82a6f127ab1d9ac2d8c0a598726b")
+        a_public = x448(a_random, bytearray(X448_G))
+
+        self.assertEqual(a_public,
+                         a2b_hex("9b08f7cc31b7e3e67d22d5aea121"
+                                 "074a273bd2b83de09c63faa73d2c"
+                                 "22c5d9bbc836647241d953d40c5b"
+                                 "12da88120d53177f80e532c41fa0"))
+
+    def test_x448_ecdh_b_share(self):
+        b_random = a2b_hex("1c306a7ac2a0e2e0990b294470cb"
+                           "a339e6453772b075811d8fad0d1d"
+                           "6927c120bb5ee8972b0d3e21374c"
+                           "9c921b09d1b0366f10b65173992d")
+        b_public = x448(b_random, bytearray(X448_G))
+
+        self.assertEqual(b_public,
+                         a2b_hex("3eb7a829b0cd20f5bcfc0b599b6f"
+                                 "eccf6da4627107bdb0d4f345b430"
+                                 "27d8b972fc3e34fb4232a13ca706"
+                                 "dcb57aec3dae07bdc1c67bf33609"))
+
+    def test_x448_ecdh_shared(self):
+        a_random = a2b_hex("9a8f4925d1519f5775cf46b04b58"
+                           "00d4ee9ee8bae8bc5565d498c28d"
+                           "d9c9baf574a94197448973910063"
+                           "82a6f127ab1d9ac2d8c0a598726b")
+        a_public = x448(a_random, bytearray(X448_G))
+
+        b_random = a2b_hex("1c306a7ac2a0e2e0990b294470cb"
+                           "a339e6453772b075811d8fad0d1d"
+                           "6927c120bb5ee8972b0d3e21374c"
+                           "9c921b09d1b0366f10b65173992d")
+        b_public = x448(b_random, bytearray(X448_G))
+
+        a_shared = x448(a_random, b_public)
+        b_shared = x448(b_random, a_public)
+
+        self.assertEqual(a_shared, b_shared)
+        self.assertEqual(a_shared,
+                         a2b_hex("07fff4181ac6cc95ec1c16a94a0f"
+                                 "74d12da232ce40a77552281d282b"
+                                 "b60c0b56fd2464c335543936521c"
+                                 "24403085d59a449a5037514a879d"))

--- a/unit_tests/test_tlslite_utils_x25519.py
+++ b/unit_tests/test_tlslite_utils_x25519.py
@@ -17,7 +17,7 @@ except ImportError:
 
 from tlslite.utils.x25519 import decodeUCoordinate, decodeScalar22519, \
         decodeScalar448, x25519, x448, X25519_G, X448_G
-from tlslite.utils.compat import a2b_hex
+from tlslite.utils.compat import a2b_hex, b2a_hex
 from tlslite.utils.cryptomath import numberToByteArray
 
 class TestDecodeUCoordinate(unittest.TestCase):
@@ -54,6 +54,7 @@ class TestDecodeUCoordinate(unittest.TestCase):
                                      "1515452463053830"))
 
 
+class TestDecodeScalar22519(unittest.TestCase):
     def test_x25519_decode_scalar(self):
         value = a2b_hex('a546e36bf0527c9d3b16154b82465edd6'
                         '2144c0ac1fc5a18506a2244ba449ac4')
@@ -64,6 +65,7 @@ class TestDecodeUCoordinate(unittest.TestCase):
                                      "72772604678260265531221036453811406496"))
 
 
+class TestDecodeScalar448(unittest.TestCase):
     def test_x448_decode_scalar(self):
         value = a2b_hex('3d262fddf9ec8e88495266fea19a34d2'
                         '8882acef045104d0d1aae121'
@@ -75,9 +77,62 @@ class TestDecodeUCoordinate(unittest.TestCase):
         self.assertEqual(int("599189175373896402783756016145213256157230856"
                              "085026129926891459468622403380588640249457727"
                              "683869421921443004045221642549886377526240828"),
-                         scalar)
+                             scalar)
 
 
+class TestUncommonInputsX25519(unittest.TestCase):
+    def test_all_zero_k(self):
+        k = bytearray(32)
+        u = a2b_hex("e6db6867583030db3594c1a424b15f7"
+                    "c726624ec26b3353b10a903a6d0ab1c4c")
+
+        ret = x25519(k, u)
+
+        self.assertEqual(ret,
+                         a2b_hex("030d7ba1a76719f96d5c39122f690e78"
+                                 "56895ee9d24416279eb9182010287113"))
+
+    def test_all_zero_u(self):
+        k = a2b_hex("a546e36bf0527c9d3b16154b82465ed"
+                    "d62144c0ac1fc5a18506a2244ba449ac4")
+        u = bytearray(32)
+
+        ret = x25519(k, u)
+
+        self.assertEqual(ret,
+                         bytearray(32))
+
+
+class TestUncommonInputsX448(unittest.TestCase):
+    def test_all_zero_k(self):
+        k = bytearray(56)
+        u = a2b_hex("06fce640fa3487bfda5f6cf2d5263f8"
+                    "aad88334cbd07437f020f08f9"
+                    "814dc031ddbdc38c19c6da2583fa542"
+                    "9db94ada18aa7a7fb4ef8a086")
+
+        ret = x448(k, u)
+
+        self.assertEqual(ret,
+                         a2b_hex("f8d21fea4fe227fa556d27ec5317d839"
+                                 "4db22217e27a96c8f7b47d36a4e15ba1"
+                                 "bef872684ba18ee5ce72577b0aed87e9"
+                                 "8a3714ab32d9d169"))
+
+    def test_all_zero_u(self):
+        k = a2b_hex("3d262fddf9ec8e88495266fea19a34d"
+                    "28882acef045104d0d1aae121"
+                    "700a779c984c24f8cdd78fbff44943e"
+                    "ba368f54b29259a4f1c600ad3")
+        u = bytearray(56)
+
+        ret = x448(k, u)
+
+        self.assertEqual(ret,
+                         bytearray(56))
+
+
+class TestKnownAnswerTests(unittest.TestCase):
     # RFC 7748 Section 5.2, vector #1
     def test_x25519_1(self):
         k = a2b_hex("a546e36bf0527c9d3b16154b82465ed"


### PR DESCRIPTION
add support for X25519 and X448 key exchange
 - [x] X25519 and XX448 functions
 - [x] [TLS ECDHE](https://tools.ietf.org/html/draft-ietf-tls-rfc4492bis-12) key exchange with X25519
 - [x] Update to [draft-ietf-tls-rfc4492bis-17](https://tools.ietf.org/html/draft-ietf-tls-rfc4492bis-17)

Closes #89 

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/tomato42/tlslite-ng/154)
<!-- Reviewable:end -->
