### PR TITLE
remove correct file on Windows

### DIFF
--- a/tests/tlstest.py
+++ b/tests/tlstest.py
@@ -876,7 +876,12 @@ def serverTestCmd(argv):
         testConnServer(connection)
         connection.close()
     finally:
-        os.remove(db_name)
+        try:
+            os.remove(db_name)
+        except FileNotFoundError:
+            # dbm module may create files with different names depending on
+            # platform
+            os.remove(db_name + ".dat")
 
     test_no += 1
 

--- a/tests/tlstest.py
+++ b/tests/tlstest.py
@@ -195,7 +195,7 @@ def clientTestCmd(argv):
 
     test_no += 1
 
-    print("Test {0} - good SRP".format(test_no))
+    print("Test {0} - good SRP (db)".format(test_no))
     synchro.recv(1)
     connection = connect()
     connection.handshakeClientSRP("test", "password")
@@ -204,7 +204,7 @@ def clientTestCmd(argv):
 
     test_no += 1
 
-    print("Test {0} - good SRP (db)".format(test_no))
+    print("Test {0} - good SRP".format(test_no))
     synchro.recv(1)
     connection = connect()
     connection.handshakeClientSRP("test", "password")
@@ -845,20 +845,6 @@ def serverTestCmd(argv):
 
     test_no += 1
 
-    print("Test {0} - good SRP".format(test_no))
-    verifierDB = VerifierDB()
-    verifierDB.create()
-    entry = VerifierDB.makeVerifier("test", "password", 1536)
-    verifierDB[b"test"] = entry
-
-    synchro.send(b'R')
-    connection = connect()
-    connection.handshakeServer(verifierDB=verifierDB)
-    testConnServer(connection)
-    connection.close()
-
-    test_no += 1
-
     print("Test {0} - good SRP (db)".format(test_no))
     try:
         (db_file, db_name) = mkstemp()
@@ -882,6 +868,20 @@ def serverTestCmd(argv):
             # dbm module may create files with different names depending on
             # platform
             os.remove(db_name + ".dat")
+
+    test_no += 1
+
+    print("Test {0} - good SRP".format(test_no))
+    verifierDB = VerifierDB()
+    verifierDB.create()
+    entry = VerifierDB.makeVerifier("test", "password", 1536)
+    verifierDB[b"test"] = entry
+
+    synchro.send(b'R')
+    connection = connect()
+    connection.handshakeServer(verifierDB=verifierDB)
+    testConnServer(connection)
+    connection.close()
 
     test_no += 1
 


### PR DESCRIPTION
the DBM module on Windows creates databases as .dat files
by default (even if the original filename did not include it)
so retry deleting alternative name if the original one failed

fixes #162

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/tomato42/tlslite-ng/164)
<!-- Reviewable:end -->
