### PR TITLE
Mandatory parts of TLS 1.3

### DIFF
--- a/scripts/tls.py
+++ b/scripts/tls.py
@@ -74,7 +74,9 @@ def printUsage(s=None):
 
   server  
     [-k KEY] [-c CERT] [-t TACK] [-v VERIFIERDB] [-d DIR] [-l LABEL] [-L LENGTH]
-    [--reqcert] [--param DHFILE] HOST:PORT
+    [--reqcert] [--param DHFILE] [--psk PSK] [--psk-ident IDENTITY]
+    [--psk-sha384]
+    HOST:PORT
 
   client
     [-k KEY] [-c CERT] [-u USER] [-p PASS] [-l LABEL] [-L LENGTH] [-a ALPN]
@@ -345,8 +347,10 @@ def clientCmd(argv):
 
 def serverCmd(argv):
     (address, privateKey, certChain, tacks, verifierDB, directory, reqCert,
-            expLabel, expLength, dhparam) = handleArgs(argv, "kctbvdlL",
-                                                       ["reqcert", "param="])
+            expLabel, expLength, dhparam, psk, psk_ident, psk_hash) = \
+        handleArgs(argv, "kctbvdlL",
+                   ["reqcert", "param=", "psk=",
+                    "psk-ident=", "psk-sha384"])
 
 
     if (certChain and not privateKey) or (not certChain and privateKey):
@@ -391,6 +395,8 @@ def serverCmd(argv):
                 settings = HandshakeSettings()
                 settings.useExperimentalTackExtension=True
                 settings.dhParams = dhparam
+                if psk:
+                    settings.pskConfigs = [(psk_ident, psk, psk_hash)]
                 connection.setsockopt(socket.IPPROTO_TCP, socket.TCP_NODELAY,
                                       1)
                 connection.handshakeServer(certChain=certChain,

--- a/tests/tlstest.py
+++ b/tests/tlstest.py
@@ -239,6 +239,18 @@ def clientTestCmd(argv):
 
     test_no += 1
 
+    print("Test {0} - good PSK".format(test_no))
+    synchro.recv(1)
+    connection = connect()
+    settings = HandshakeSettings()
+    settings.pskConfigs = [(b'test', b'\x00secret', 'sha384')]
+    connection.handshakeClientCert(settings=settings)
+    assert connection.session.serverCertChain is None
+    testConnClient(connection)
+    connection.close()
+
+    test_no += 1
+
     print("Test {0} - good SRP (db)".format(test_no))
     print("client {0} - waiting for synchro".format(time.time()))
     synchro.recv(1)
@@ -994,6 +1006,18 @@ def serverTestCmd(argv):
 
         print("Test {0} - good X.509, TACK unrelated to cert chain"
               "...skipped (no tackpy)".format(test_no))
+
+    test_no += 1
+
+    print("Test {0} - good PSK".format(test_no))
+    synchro.send(b'R')
+    settings = HandshakeSettings()
+    settings.pskConfigs = [(b'test', b'\x00secret', 'sha384')]
+    connection = connect()
+    connection.handshakeServer(certChain=x509Chain, privateKey=x509Key,
+                               settings=settings)
+    testConnServer(connection)
+    connection.close()
 
     test_no += 1
 

--- a/tlslite/constants.py
+++ b/tlslite/constants.py
@@ -15,7 +15,7 @@ from .utils.compat import a2b_hex
 
 # protocol version number used for negotiating TLS 1.3 between implementations
 # of the draft specification
-TLS_1_3_DRAFT = (127, 23)
+TLS_1_3_DRAFT = (127, 26)
 
 
 # ServerHello.random value meaning that the message is a HelloRetryRequest

--- a/tlslite/handshakehelpers.py
+++ b/tlslite/handshakehelpers.py
@@ -134,7 +134,8 @@ class HandshakeHelpers(object):
             ext.binders[i] = binder
 
     @staticmethod
-    def verify_binder(client_hello, handshake_hashes, position, secret, prf):
+    def verify_binder(client_hello, handshake_hashes, position, secret, prf,
+                      external=True):
         """Verify the PSK binder value in client hello.
 
         :param client_hello: ClientHello to verify
@@ -154,7 +155,8 @@ class HandshakeHelpers(object):
 
         binder = HandshakeHelpers._calc_binder(prf,
                                                secret,
-                                               hh)
+                                               hh,
+                                               external)
 
         if not ct_compare_digest(binder, ext.binders[position]):
             raise TLSIllegalParameterException("Binder does not verify")

--- a/tlslite/handshakehelpers.py
+++ b/tlslite/handshakehelpers.py
@@ -41,7 +41,7 @@ class HandshakeHelpers(object):
             clientHello.extensions.append(paddingExtensionInstance)
 
     @staticmethod
-    def _calc_binder(prf, psk, handshake_hash):
+    def _calc_binder(prf, psk, handshake_hash, external=True):
         """
         Calculate the binder value for a given HandshakeHash (that includes
         a truncated client hello already)
@@ -51,14 +51,30 @@ class HandshakeHelpers(object):
 
         # HKDF-Extract(0, PSK)
         early_secret = secureHMAC(bytearray(key_len), psk, prf)
-        binder_key = derive_secret(early_secret, b"ext binder", None, prf)
+        if external:
+            binder_key = derive_secret(early_secret, b"ext binder", None, prf)
+        else:
+            binder_key = derive_secret(early_secret, b"res binder", None, prf)
         finished_key = HKDF_expand_label(binder_key, b"finished", b"", key_len,
                                          prf)
         binder = secureHMAC(finished_key, handshake_hash.digest(prf), prf)
         return binder
 
     @staticmethod
-    def update_binders(client_hello, handshake_hashes, psk_configs):
+    def calc_res_binder_psk(iden, res_master_secret, tickets):
+        """Calculate PSK associated with provided ticket identity."""
+        ticket = [i for i in tickets if i.ticket == iden.identity][0]
+
+        ticket_hash = 'sha256' if len(res_master_secret) == 32 else 'sha384'
+
+        psk = HKDF_expand_label(res_master_secret, b"resumption",
+                                ticket.ticket_nonce, len(res_master_secret),
+                                ticket_hash)
+        return psk
+
+    @staticmethod
+    def update_binders(client_hello, handshake_hashes, psk_configs,
+                       tickets=None, res_master_secret=None):
         """
         Sign the Client Hello using TLS 1.3 PSK binders.
 
@@ -68,32 +84,51 @@ class HandshakeHelpers(object):
         :param client_hello: ClientHello to sign
         :param handshake_hashes: hashes of messages exchanged so far
         :param psk_configs: PSK identities and secrets
+        :param tickets: optional list of tickets received from server
+        :param bytearray res_master_secret: secret associated with the
+            tickets
         """
         ext = client_hello.extensions[-1]
         if not isinstance(ext, PreSharedKeyExtension):
             raise ValueError("Last extension in client_hello must be "
                              "PreSharedKeyExtension")
+        if tickets and not res_master_secret:
+            raise ValueError("Tickets require setting res_master_secret")
 
         hh = handshake_hashes.copy()
 
         hh.update(client_hello.psk_truncate())
 
         configs_iter = iter(psk_configs)
+        ticket_idens = []
+        if tickets:
+            ticket_idens = [i.ticket for i in tickets]
 
         for i, iden in enumerate(ext.identities):
-            try:
-                config = next(configs_iter)
-                while config[0] != iden.identity:
+            # identities that are tickets don't carry PSK directly
+            if iden.identity in ticket_idens:
+                binder_hash = 'sha256' if len(res_master_secret) == 32 \
+                    else 'sha384'
+                psk = HandshakeHelpers.calc_res_binder_psk(
+                    iden, res_master_secret, tickets)
+                external = False
+            else:
+                try:
                     config = next(configs_iter)
-            except StopIteration:
-                raise ValueError("psk_configs don't match the "
-                                 "PreSharedKeyExtension")
+                    while config[0] != iden.identity:
+                        config = next(configs_iter)
+                except StopIteration:
+                    raise ValueError("psk_configs don't match the "
+                                     "PreSharedKeyExtension")
 
-            binder_hash = config[2] if len(config) > 2 else 'sha256'
+                binder_hash = config[2] if len(config) > 2 else 'sha256'
+                psk = config[1]
+                external = True
 
             binder = HandshakeHelpers._calc_binder(binder_hash,
-                                                   config[1],
-                                                   hh)
+                                                   psk,
+                                                   hh,
+                                                   external)
 
             # replace the fake value with calculated one
             ext.binders[i] = binder

--- a/tlslite/messages.py
+++ b/tlslite/messages.py
@@ -1894,6 +1894,9 @@ class NewSessionTicket(HelloMessage):
         self.ticket_nonce = bytearray(0)
         self.ticket = bytearray(0)
         self.extensions = []
+        # time at which the ticket was received, not sent on the wire
+        # in seconds in Unix Epoch
+        self.time = None
 
     def create(self, ticket_lifetime, ticket_age_add, ticket_nonce, ticket,
                extensions):

--- a/tlslite/session.py
+++ b/tlslite/session.py
@@ -50,6 +50,21 @@ class Session(object):
     :vartype appProto: bytearray
     :ivar appProto: name of the negotiated application level protocol, None
         if not negotiated
+
+    :vartype cl_app_secret: bytearray
+    :ivar cl_app_secret: key used for deriving keys used by client to encrypt
+        and protect data in TLS 1.3
+
+    :vartype sr_app_secret: bytearray
+    :ivar sr_app_secret: key used for deriving keys used by server to encrypt
+        and protect data in TLS 1.3
+
+    :vartype exporterMasterSecret: bytearray
+    :ivar exporterMasterSecret: master secret used for TLS Exporter in TLS1.3
+
+    :vartype resumptionMasterSecret: bytearray
+    :ivar resumptionMasterSecret: master secret used for session resumption in
+        TLS 1.3
     """
 
     def __init__(self):
@@ -66,12 +81,18 @@ class Session(object):
         self.encryptThenMAC = False
         self.extendedMasterSecret = False
         self.appProto = bytearray(0)
+        self.cl_app_secret = bytearray(0)
+        self.sr_app_secret = bytearray(0)
+        self.exporterMasterSecret = bytearray(0)
+        self.resumptionMasterSecret = bytearray(0)
 
     def create(self, masterSecret, sessionID, cipherSuite,
                srpUsername, clientCertChain, serverCertChain,
                tackExt, tackInHelloExt, serverName, resumable=True,
                encryptThenMAC=False, extendedMasterSecret=False,
-               appProto=bytearray(0)):
+               appProto=bytearray(0), cl_app_secret=bytearray(0),
+               sr_app_secret=bytearray(0), exporterMasterSecret=bytearray(0),
+               resumptionMasterSecret=bytearray(0)):
         self.masterSecret = masterSecret
         self.sessionID = sessionID
         self.cipherSuite = cipherSuite
@@ -85,6 +106,10 @@ class Session(object):
         self.encryptThenMAC = encryptThenMAC
         self.extendedMasterSecret = extendedMasterSecret
         self.appProto = appProto
+        self.cl_app_secret = cl_app_secret
+        self.sr_app_secret = sr_app_secret
+        self.exporterMasterSecret = exporterMasterSecret
+        self.resumptionMasterSecret = resumptionMasterSecret
 
     def _clone(self):
         other = Session()
@@ -101,6 +126,10 @@ class Session(object):
         other.encryptThenMAC = self.encryptThenMAC
         other.extendedMasterSecret = self.extendedMasterSecret
         other.appProto = self.appProto
+        other.cl_app_secret = self.cl_app_secret
+        other.sr_app_secret = self.sr_app_secret
+        other.exporterMasterSecret = self.exporterMasterSecret
+        other.resumptionMasterSecret = self.resumptionMasterSecret
         return other
 
     def valid(self):
@@ -109,6 +138,7 @@ class Session(object):
         :rtype: bool
         :returns: If this session can be used for session resumption.
         """
+        # TODO add checks for tickets received from server (freshness etc.)
         return self.resumable and self.sessionID
 
     def _setResumable(self, boolean):

--- a/tlslite/session.py
+++ b/tlslite/session.py
@@ -146,7 +146,7 @@ class Session(object):
         :returns: If this session can be used for session resumption.
         """
         # TODO add checks for tickets received from server (freshness etc.)
-        return self.resumable and self.sessionID
+        return self.resumable and (self.sessionID or self.tickets)
 
     def _setResumable(self, boolean):
         #Only let it be set to True if the sessionID is non-null

--- a/tlslite/session.py
+++ b/tlslite/session.py
@@ -65,6 +65,9 @@ class Session(object):
     :vartype resumptionMasterSecret: bytearray
     :ivar resumptionMasterSecret: master secret used for session resumption in
         TLS 1.3
+
+    :vartype tickets: list
+    :ivar tickets: list of tickets received from the server
     """
 
     def __init__(self):
@@ -85,6 +88,7 @@ class Session(object):
         self.sr_app_secret = bytearray(0)
         self.exporterMasterSecret = bytearray(0)
         self.resumptionMasterSecret = bytearray(0)
+        self.tickets = None
 
     def create(self, masterSecret, sessionID, cipherSuite,
                srpUsername, clientCertChain, serverCertChain,
@@ -92,7 +96,7 @@ class Session(object):
                encryptThenMAC=False, extendedMasterSecret=False,
                appProto=bytearray(0), cl_app_secret=bytearray(0),
                sr_app_secret=bytearray(0), exporterMasterSecret=bytearray(0),
-               resumptionMasterSecret=bytearray(0)):
+               resumptionMasterSecret=bytearray(0), tickets=None):
         self.masterSecret = masterSecret
         self.sessionID = sessionID
         self.cipherSuite = cipherSuite
@@ -110,6 +114,8 @@ class Session(object):
         self.sr_app_secret = sr_app_secret
         self.exporterMasterSecret = exporterMasterSecret
         self.resumptionMasterSecret = resumptionMasterSecret
+        # NOTE we need a reference copy not a copy of object here!
+        self.tickets = tickets
 
     def _clone(self):
         other = Session()
@@ -130,6 +136,7 @@ class Session(object):
         other.sr_app_secret = self.sr_app_secret
         other.exporterMasterSecret = self.exporterMasterSecret
         other.resumptionMasterSecret = self.resumptionMasterSecret
+        other.tickets = self.tickets
         return other
 
     def valid(self):

--- a/tlslite/tlsconnection.py
+++ b/tlslite/tlsconnection.py
@@ -2320,8 +2320,7 @@ class TLSConnection(TLSRecordLayer):
         # occurs parsing the ClientHello, this will be the version we'll use
         # for the error alert
         # If TLS 1.3 is enabled, use the "compatible" TLS 1.2 version
-        self.version = settings.maxVersion if settings.maxVersion < (3, 4) \
-                       else (3, 3)
+        self.version = min(settings.maxVersion, (3, 3))
 
         self._pre_client_hello_handshake_hash = self._handshake_hash.copy()
         #Get ClientHello
@@ -2511,12 +2510,11 @@ class TLSConnection(TLSRecordLayer):
         elif clientHello.client_version > settings.maxVersion:
             # in TLS 1.3 the version is negotiatied with extension,
             # but the settings use the (3, 4) as the max version
-            self.version = settings.maxVersion if settings.maxVersion < (3, 4)\
-                           else (3, 3)
+            self.version = min(settings.maxVersion, (3, 3))
             version = self.version
         else:
             #Set the version to the client's version
-            self.version = clientHello.client_version
+            self.version = min(clientHello.client_version, (3, 3))
             version = self.version
 
         #Detect if the client performed an inappropriate fallback.

--- a/tlslite/tlsconnection.py
+++ b/tlslite/tlsconnection.py
@@ -2518,10 +2518,10 @@ class TLSConnection(TLSRecordLayer):
             version = self.version
 
         #Detect if the client performed an inappropriate fallback.
-        if clientHello.client_version < settings.maxVersion and \
-            CipherSuite.TLS_FALLBACK_SCSV in clientHello.cipher_suites:
-            for result in self._sendError(\
-                  AlertDescription.inappropriate_fallback):
+        if version < settings.maxVersion and \
+                CipherSuite.TLS_FALLBACK_SCSV in clientHello.cipher_suites:
+            for result in self._sendError(
+                    AlertDescription.inappropriate_fallback):
                 yield result
 
         # TODO when TLS 1.3 is final, check the client hello random for

--- a/tlslite/tlsconnection.py
+++ b/tlslite/tlsconnection.py
@@ -1216,7 +1216,9 @@ class TLSConnection(TLSRecordLayer):
                             cl_app_secret=cl_app_traffic,
                             sr_app_secret=sr_app_traffic,
                             exporterMasterSecret=exporter_master_secret,
-                            resumptionMasterSecret=resumption_master_secret)
+                            resumptionMasterSecret=resumption_master_secret,
+                            # NOTE it must be a reference, not a copy!
+                            tickets=self.tickets)
 
         yield "finished"
 

--- a/tlslite/tlsrecordlayer.py
+++ b/tlslite/tlsrecordlayer.py
@@ -12,6 +12,7 @@
 from __future__ import generators
 
 import io
+import time
 import socket
 
 from .utils.compat import *
@@ -262,6 +263,7 @@ class TLSRecordLayer(object):
                         if result in (0, 1):
                             yield result
                     if isinstance(result, NewSessionTicket):
+                        result.time = time.time()
                         self.tickets.append(result)
                         continue
                     applicationData = result

--- a/tlslite/tlsrecordlayer.py
+++ b/tlslite/tlsrecordlayer.py
@@ -904,6 +904,9 @@ class TLSRecordLayer(object):
                     yield result
                 else:
                     break
+        except TLSUnexpectedMessage:
+            for result in self._sendError(AlertDescription.unexpected_message):
+                yield result
         except TLSRecordOverflow:
             for result in self._sendError(AlertDescription.record_overflow):
                 yield result

--- a/unit_tests/test_tlslite_handshakesettings.py
+++ b/unit_tests/test_tlslite_handshakesettings.py
@@ -342,6 +342,33 @@ class TestHandshakeSettings(unittest.TestCase):
 
         self.assertIn("wrong-hash", str(e.exception))
 
+    def test_ticketCipher_invalid(self):
+        hs = HandshakeSettings()
+        hs.ticketCipher = "aes-128-cbc"
+
+        with self.assertRaises(ValueError) as e:
+            hs.validate()
+
+        self.assertIn("Invalid cipher", str(e.exception))
+
+    def test_ticketKeys_wrong_size(self):
+        hs = HandshakeSettings()
+        hs.ticketKeys = [bytearray(8)]
+
+        with self.assertRaises(ValueError) as e:
+            hs.validate()
+
+        self.assertIn("encryption keys", str(e.exception))
+
+    def test_ticketLifetime_wrong(self):
+        hs = HandshakeSettings()
+        hs.ticketLifetime = 2**32
+
+        with self.assertRaises(ValueError) as e:
+            hs.validate()
+
+        self.assertIn("ticket lifetime", str(e.exception))
+
 
 if __name__ == '__main__':
     unittest.main()

--- a/unit_tests/test_tlslite_handshakesettings.py
+++ b/unit_tests/test_tlslite_handshakesettings.py
@@ -367,7 +367,7 @@ class TestHandshakeSettings(unittest.TestCase):
         with self.assertRaises(ValueError) as e:
             hs.validate()
 
-        self.assertIn("ticket lifetime", str(e.exception))
+        self.assertIn("Ticket lifetime", str(e.exception))
 
 
 if __name__ == '__main__':

--- a/unit_tests/test_tlslite_recordlayer.py
+++ b/unit_tests/test_tlslite_recordlayer.py
@@ -547,8 +547,8 @@ class TestRecordLayer(unittest.TestCase):
             b'\x00\x15'  # length
             ))
         self.assertEqual(sock.sent[0][5:], bytearray(
-            b'\xe1\x90\x2d\xd1\xfd\x24\xc8\x47\x70\xd4'
-            b'\x8c\x36\xf3\x2c\x93\x04\x39\x1f\x6f\x42\xeb'
+            b"\xe1\x90\x2d\xd1\xfd"
+            b'u\xdd\xa0\xb1VYB&\xe8\x05\xb1~\xe5u\x9a\x0f'
             ))
 
     def test_recvRecord_with_encryption_tls1_3_aes_128_gcm(self):
@@ -562,8 +562,8 @@ class TestRecordLayer(unittest.TestCase):
             b'\x17'  # application_data
             b'\x03\x01'  # hidden protocol version - TLS 1.x
             b'\x00\x15'  # length
-            b'\xe1\x90\x2d\xd1\xfd\x24\xc8\x47\x70\xd4'
-            b'\x8c\x36\xf3\x2c\x93\x04\x39\x1f\x6f\x42\xeb'
+            b"\xe1\x90\x2d\xd1\xfd"
+            b'u\xdd\xa0\xb1VYB&\xe8\x05\xb1~\xe5u\x9a\x0f'
             ))
 
         recordLayer = RecordLayer(sock)
@@ -621,7 +621,8 @@ class TestRecordLayer(unittest.TestCase):
             b'\x00\x15'  # length
             ))
         self.assertEqual(sock.sent[0][5:], bytearray(
-            b'}\x17w_#\xf0\xf2R\xaa*s\xe2\xca\xab\x9d\xea\x9d\xf3\xc1-\xd2'
+            b'}\x17w_#'
+            b'\xfc\\\xaf\x1ef6\x03X\xd2\xe3\x1c\xe4]\xcb\xb7\xbb'
             ))
 
     def test_sendRecord_with_encryption_tls1_3_chacha20(self):
@@ -657,7 +658,8 @@ class TestRecordLayer(unittest.TestCase):
             b'\x00\x15'  # length
             ))
         self.assertEqual(sock.sent[0][5:], bytearray(
-            b'o\x9fO\x16\x07\x878]GV\xa5l\x12\xb6\x85\xb5@\x83\x94\x06\xd6'
+            b'o\x9fO\x16\x07'
+            b'\xbdUy\x17E6\n\xd9\x9cT\xec\xdav\x1f\xb4$'
             ))
 
     def test_sendRecord_with_padding_tls1_3(self):
@@ -707,9 +709,8 @@ class TestRecordLayer(unittest.TestCase):
             b"\xf6\x10\xe5}\xb1T\x85om\xa4\xfa\x1aS\x1f\xab\xc6b\'\xe6f" +
             b"\xb3\xbe\xac\xfd\xed\x06\x93\xadbGMD\xd9\xb9\xca\xf6\x8b" +
             b"\xac\x07\x96\xe8\xd13)r\xbcNJ\x9d#YP@\x9b\x8ez\x06\xfb" +
-            b"\x8f2\x8cz\xb7\xd6IP\xfa\xeezcQ\xf3\xe2n\x82\xd1\x9f\xd1x" +
-            b"\x01x\xea\xd4ht[)\x06"
-            ))
+            b"\x8f2\x8cz\xb7\xd6IP\xfa\xeezcQ\xf3"
+            b"(\t\x8e\x0b\xf8\x02\xb4\x9du\xa0f\x88;\xb9\xfd\x87"))
 
     def test_sendRecord_with_malformed_inner_plaintext(self):
         # setup
@@ -748,7 +749,8 @@ class TestRecordLayer(unittest.TestCase):
             b'\x00\x15'  # length
             ))
         self.assertEqual(sock.sent[0][5:], bytearray(
-            b'\x95\xf5^\xa5\xea\x8cCf\xbb\xbb\xe2\xdb!\x13\xf1\x1b\x93s\x81>M'
+            b'\x95\xf5^\xa5\xea'
+            b'\xddV\x81z97\xaf\xf4\xd7g\xae\xd4\x89\x9b\xe6\xa9'
             ))
 
         # test proper


### PR DESCRIPTION
Work in progress on TLS 1.3 support.

Includes:
 - messages themselves
 - documentation
 - test cases

 - [x] general Client
   - [x] 1-RTT
   - [x] 1-RTT with HRR
   - [x] 1-RTT with PSK (and HRR)
   - [x] 1-RTT with session resumption
 - [x] general Server
   - [x] 1-RTT
   - [x] 1-RTT with HRR
   - [x] 1-RTT with PSK (and HRR)
   - [x] 1-RTT with session resumption

 - [x] Record Layer
   - [x] AES-128-GCM
   - [x] AES-256-GCM
   - [x] Chacha20/Poly1305
 - [x] Key Share extension
    - [x] Client Hello
    - [x] Hello Retry Request
    - [x] Server Hello
   - key types:
     - [x] X25519, X448
     - [x] ECDHE (P-256, P-384, P-521)
     - [x] FFDHE
 - [x] Supported Versions extension
 - [x] Supported Groups extension from server
 - [x] Encrypted Extensions message
 - [x] Hello Retry Request message
 - [x] Finished message
 - [x] Certificate message
 - [x] New Session Ticket message
   - [x] receiving it at any moment
- [x] Cookie extension
- [x] Sending supported groups in Encrypted Extensions
- [x] fake Change Cipher Spec
- [x] `signature_algorithms_cert`
  - [x] rsa_pss_pss_* hashes

Will fix #39 once ready

more clever ciphersuite selection (for external PSKs) will be handled in #213 

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/tomato42/tlslite-ng/174)
<!-- Reviewable:end -->
