### PR TITLE
fix long for pycrypto

### DIFF
--- a/tlslite/utils/pycrypto_rsakey.py
+++ b/tlslite/utils/pycrypto_rsakey.py
@@ -29,12 +29,10 @@ if pycryptoLoaded:
             return self.rsa.has_private()
 
         def _rawPrivateKeyOp(self, m):
-            c = self.rsa.decrypt((m,))
-            return c
+            return self.rsa.decrypt((compatLong(m),))
 
         def _rawPublicKeyOp(self, c):
-            m = self.rsa.encrypt(c, None)[0]
-            return m
+            return self.rsa.encrypt(compatLong(c), None)[0]
 
         def generate(bits):
             key = PyCrypto_RSAKey()


### PR DESCRIPTION
PyCrypto on Python 2.7 expects longs not only for initialisation
of RSA keys but also for RSA operations - fix that.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/tomato42/tlslite-ng/177)
<!-- Reviewable:end -->
