### PR TITLE
Test coverage for tlslite.messages module, minor fixes

### DIFF
--- a/.codeclimate.yml
+++ b/.codeclimate.yml
@@ -16,6 +16,12 @@ engines:
       - python
   fixme:
     enabled: true
+    config:
+      strings:
+        - TODO
+        - FIXME
+        - HACK
+        - BUG
     checks:
       bug:
         enabled: true

--- a/tlslite/messages.py
+++ b/tlslite/messages.py
@@ -816,18 +816,23 @@ class ServerHello(HelloMessage):
         :type val: list
         :param val: list of protocols to advertise as UTF-8 encoded names
         """
-        if val is None:
-            return
-        else:
+        if val is not None:
             # convinience function, make sure the values are properly encoded
             val = [bytearray(x) for x in val]
 
         npn_ext = self.getExtension(ExtensionType.supports_npn)
 
         if npn_ext is None:
+            if val is None:
+                # XXX: do not send empty extension
+                return
             ext = NPNExtension().create(val)
             self.addExtension(ext)
         else:
+            if val is None:
+                # XXX: do not send empty extension
+                self._removeExt(ExtensionType.supports_npn)
+                return
             npn_ext.protocols = val
 
     @property

--- a/tlslite/messages.py
+++ b/tlslite/messages.py
@@ -779,15 +779,19 @@ class ServerHello(HelloMessage):
         :type val: int
         :param val: type of certificate
         """
-        # XXX backwards compatibility, 0 means x.509 and should not be sent
-        if val == 0 or val is None:
-            return
-
         cert_type = self.getExtension(ExtensionType.cert_type)
         if cert_type is None:
+            # XXX backwards compatibility, 0 means x.509 and should not be sent
+            if val == CertificateType.x509 or val is None:
+                return
             ext = ServerCertTypeExtension().create(val)
             self.addExtension(ext)
         else:
+            if val == CertificateType.x509 or val is None:
+                # XXX backwards compatibility, 0 means x.509 and should not be
+                # sent
+                self._removeExt(ExtensionType.cert_type)
+                return
             cert_type.cert_type = val
 
     @property

--- a/unit_tests/test_tlslite_messages.py
+++ b/unit_tests/test_tlslite_messages.py
@@ -11,7 +11,7 @@ from tlslite.messages import ClientHello, ServerHello, RecordHeader3, Alert, \
         RecordHeader2, Message, ClientKeyExchange, ServerKeyExchange, \
         CertificateRequest, CertificateVerify, ServerHelloDone, ServerHello2, \
         ClientMasterKey, ClientFinished, ServerFinished, CertificateStatus, \
-        Certificate, Finished, HelloMessage
+        Certificate, Finished, HelloMessage, ChangeCipherSpec
 from tlslite.utils.codec import Parser
 from tlslite.constants import CipherSuite, CertificateType, ContentType, \
         AlertLevel, AlertDescription, ExtensionType, ClientCertificateType, \
@@ -2782,6 +2782,36 @@ class TestCertificate(unittest.TestCase):
 
         with self.assertRaises(AssertionError):
             cert.write()
+
+
+class TestChangeCipherSpec(unittest.TestCase):
+    def test___init__(self):
+        ccs = ChangeCipherSpec()
+
+        self.assertIsNotNone(ccs)
+        self.assertEqual(ccs.type, 1)
+
+    def test_create(self):
+        ccs = ChangeCipherSpec().create()
+
+        self.assertIsNotNone(ccs)
+        self.assertIsInstance(ccs, ChangeCipherSpec)
+
+        self.assertEqual(ccs.type, 1)
+
+    def test_write(self):
+        ccs = ChangeCipherSpec().create()
+
+        self.assertEqual(bytearray(b'\x01'), ccs.write())
+
+    def test_parse(self):
+        parser = Parser(bytearray(b'\x01'))
+
+        ccs = ChangeCipherSpec()
+        ccs = ccs.parse(parser)
+
+        self.assertIsInstance(ccs, ChangeCipherSpec)
+        self.assertEqual(ccs.type, 1)
 
 
 if __name__ == '__main__':

--- a/unit_tests/test_tlslite_messages.py
+++ b/unit_tests/test_tlslite_messages.py
@@ -858,7 +858,6 @@ class TestServerHello(unittest.TestCase):
         self.assertEqual([bytearray(b'spdy/3'), bytearray(b'http/1.1')],
                          server_hello.next_protos)
 
-    @unittest.expectedFailure
     def test_next_protos_reset_to_None(self):
         server_hello = ServerHello().create(
                 (1,1),                          # server version

--- a/unit_tests/test_tlslite_messages.py
+++ b/unit_tests/test_tlslite_messages.py
@@ -16,7 +16,8 @@ from tlslite.utils.codec import Parser
 from tlslite.constants import CipherSuite, CertificateType, ContentType, \
         AlertLevel, AlertDescription, ExtensionType, ClientCertificateType, \
         HashAlgorithm, SignatureAlgorithm, ECCurveType, GroupName, \
-        SSL2HandshakeType, CertificateStatusType, HandshakeType
+        SSL2HandshakeType, CertificateStatusType, HandshakeType, \
+        SignatureScheme
 from tlslite.extensions import SNIExtension, ClientCertTypeExtension, \
     SRPExtension, TLSExtension, NPNExtension
 from tlslite.errors import TLSInternalError
@@ -2210,6 +2211,21 @@ class TestServerKeyExchange(unittest.TestCase):
             b'\xcb\xe6\xd3=\x8b$\xff\x97e&\xb2\x89\x1dA\xab>' +
             b'\x8e?YW\xcd\xad\xc6\x83\x91\x1d.fe,\x17y' +
             b'=\xc4T\x89'))
+
+    def test_hash_with_rsa_pss_sha256(self):
+        ske = ServerKeyExchange(
+                CipherSuite.TLS_DHE_RSA_WITH_AES_128_CBC_SHA,
+                (3, 3))
+
+        ske.createDH(dh_p=31, dh_g=2, dh_Ys=16)
+        ske.hashAlg, ske.signAlg = SignatureScheme.rsa_pss_sha256
+
+        hash1 = ske.hash(bytearray(32), bytearray(32))
+
+        self.assertEqual(hash1,
+                         bytearray(b'^\xfe\x0e\x8f\xd2\x87\x8e/%\xbeK9\xb7$'
+                                   b'\x93\x9a\x81TW\nI\xff\xb2\xbeo\xaf\x90'
+                                   b'\xa7\xfb\xe1sM'))
 
     def test_hash_with_invalid_ciphersuite(self):
         ske = ServerKeyExchange(0, (3, 1))

--- a/unit_tests/test_tlslite_messages.py
+++ b/unit_tests/test_tlslite_messages.py
@@ -2436,6 +2436,32 @@ class TestServerHelloDone(unittest.TestCase):
 
         self.assertIsNotNone(shd)
 
+    def test_create(self):
+        shd = ServerHelloDone().create()
+
+        self.assertIsInstance(shd, ServerHelloDone)
+
+    def test_parse(self):
+        p = Parser(bytearray(b'\x00\x00\x00'))
+        shd = ServerHelloDone()
+
+        shd = shd.parse(p)
+
+        self.assertIsInstance(shd, ServerHelloDone)
+
+    def test_parse_with_payload(self):
+        p = Parser(bytearray(b'\x00\x00\x01\x00'))
+        shd = ServerHelloDone()
+
+        with self.assertRaises(SyntaxError):
+            shd.parse(p)
+
+    def test_write(self):
+        shd = ServerHelloDone()
+
+        self.assertEqual(bytearray(b'\x0e\x00\x00\x00'),
+                         shd.write())
+
     def test___repr__(self):
         shd = ServerHelloDone()
 

--- a/unit_tests/test_tlslite_messages.py
+++ b/unit_tests/test_tlslite_messages.py
@@ -622,7 +622,7 @@ class TestClientHello(unittest.TestCase):
 
         self.assertEqual(client_hello.server_name, bytearray(0))
 
-    def test_parse_with_SSLv2_client_hello(self):
+    def test_parse_with_SSLv2_client_hello_and_short_random(self):
         parser = Parser(bytearray(
             # length and type is handled by hello protocol parser
             #b'\x80\x2e' +           # length - 46 bytes

--- a/unit_tests/test_tlslite_messages.py
+++ b/unit_tests/test_tlslite_messages.py
@@ -11,7 +11,7 @@ from tlslite.messages import ClientHello, ServerHello, RecordHeader3, Alert, \
         RecordHeader2, Message, ClientKeyExchange, ServerKeyExchange, \
         CertificateRequest, CertificateVerify, ServerHelloDone, ServerHello2, \
         ClientMasterKey, ClientFinished, ServerFinished, CertificateStatus, \
-        Certificate
+        Certificate, Finished
 from tlslite.utils.codec import Parser
 from tlslite.constants import CipherSuite, CertificateType, ContentType, \
         AlertLevel, AlertDescription, ExtensionType, ClientCertificateType, \
@@ -2366,6 +2366,67 @@ class TestServerHelloDone(unittest.TestCase):
         shd = ServerHelloDone()
 
         self.assertEqual("ServerHelloDone()", repr(shd))
+
+
+class TestFinished(unittest.TestCase):
+    def test___init__(self):
+        finished = Finished((3, 3))
+
+        self.assertIsNotNone(finished)
+        self.assertEqual(finished.handshakeType, 20)
+
+    def test_parse_ssl2(self):
+        finished = Finished((2, 0))
+
+        parser = Parser(bytearray(b'\x00\x00\x24' +
+                                  b'\x0f' * 0x24))
+
+        with self.assertRaises(AssertionError):
+            finished.parse(parser)
+
+    def test_parse_ssl3(self):
+        finished = Finished((3, 0))
+
+        parser = Parser(bytearray(b'\x00\x00\x24' +
+                                  b'\x0f' * 0x24))
+
+        finished = finished.parse(parser)
+
+        self.assertEqual(finished.verify_data, bytearray(b'\x0f' * 36))
+
+    def test_write_ssl3(self):
+        finished = Finished((3, 0))
+
+        finished = finished.create(bytearray(b'\x03' * 36))
+
+        self.assertEqual(finished.write(),
+                bytearray(b'\x14' + b'\x00\x00\x24' + b'\x03' * 36))
+
+    def test_parse_tls_1_2(self):
+        finished = Finished((3, 3))
+
+        parser = Parser(bytearray(b'\x00\x00\x0c' + b'\x04' * 12))
+
+        finished = finished.parse(parser)
+
+        self.assertEqual(finished.verify_data, bytearray(b'\x04' * 12))
+
+    def test_parse_tls_1_2_with_invalid_number_of_bytes(self):
+        finished = Finished((3, 3))
+
+        parser = Parser(bytearray(b'\x00\x00\x0d' + b'\x04' * 13))
+
+        with self.assertRaises(SyntaxError):
+            finished.parse(parser)
+
+    def test_write_tls_1_2(self):
+        finished = Finished((3, 3))
+
+        finished = finished.create(bytearray(b'\x04' * 12))
+
+        self.assertEqual(finished.write(),
+                         bytearray(b'\x14' + b'\x00\x00\x0c' + b'\x04' * 12))
+
 
 class TestClientFinished(unittest.TestCase):
     def test___init__(self):

--- a/unit_tests/test_tlslite_messages.py
+++ b/unit_tests/test_tlslite_messages.py
@@ -11,12 +11,12 @@ from tlslite.messages import ClientHello, ServerHello, RecordHeader3, Alert, \
         RecordHeader2, Message, ClientKeyExchange, ServerKeyExchange, \
         CertificateRequest, CertificateVerify, ServerHelloDone, ServerHello2, \
         ClientMasterKey, ClientFinished, ServerFinished, CertificateStatus, \
-        Certificate, Finished
+        Certificate, Finished, HelloMessage
 from tlslite.utils.codec import Parser
 from tlslite.constants import CipherSuite, CertificateType, ContentType, \
         AlertLevel, AlertDescription, ExtensionType, ClientCertificateType, \
         HashAlgorithm, SignatureAlgorithm, ECCurveType, GroupName, \
-        SSL2HandshakeType, CertificateStatusType
+        SSL2HandshakeType, CertificateStatusType, HandshakeType
 from tlslite.extensions import SNIExtension, ClientCertTypeExtension, \
     SRPExtension, TLSExtension, NPNExtension
 from tlslite.errors import TLSInternalError
@@ -52,6 +52,23 @@ class TestMessage(unittest.TestCase):
         msg = Message(0, bytearray(10))
 
         self.assertEqual(bytearray(10), msg.write())
+
+
+class TestHelloMessage(unittest.TestCase):
+    def test___init__(self):
+        msg = HelloMessage(HandshakeType.client_hello)
+
+        self.assertIsInstance(msg, HelloMessage)
+
+    def test_addExtension(self):
+        msg = HelloMessage(HandshakeType.client_hello)
+        msg.extensions = []
+
+        msg.addExtension(SNIExtension().create(bytearray(b'example.com')))
+
+        self.assertEqual(msg.extensions,
+                         [SNIExtension().create(bytearray(b'example.com'))])
+
 
 class TestClientHello(unittest.TestCase):
     def test___init__(self):

--- a/unit_tests/test_tlslite_messages.py
+++ b/unit_tests/test_tlslite_messages.py
@@ -1030,6 +1030,20 @@ class TestServerHello(unittest.TestCase):
         server_hello = ServerHello().parse(p)
         self.assertEqual(1, server_hello.certificate_type)
 
+    def test_parse_with_no_extensions(self):
+        p = Parser(bytearray(
+            b'\x00\x00\x26' +               # length - 45 bytes
+            b'\x03\x03' +                   # version - TLS 1.2
+            b'\x01'*31 + b'\x02' +          # random
+            b'\x00' +                       # session id length
+            b'\x00\x9d' +                   # cipher suite
+            b'\x00'                         # compression method (none)
+            ))
+
+        server_hello = ServerHello().parse(p)
+        self.assertIsNone(server_hello.extensions)
+
+
     def test_parse_with_bad_cert_type_extension(self):
         p = Parser(bytearray(
             b'\x00\x00\x2e' +               # length - 46 bytes

--- a/unit_tests/test_tlslite_messages.py
+++ b/unit_tests/test_tlslite_messages.py
@@ -11,7 +11,8 @@ from tlslite.messages import ClientHello, ServerHello, RecordHeader3, Alert, \
         RecordHeader2, Message, ClientKeyExchange, ServerKeyExchange, \
         CertificateRequest, CertificateVerify, ServerHelloDone, ServerHello2, \
         ClientMasterKey, ClientFinished, ServerFinished, CertificateStatus, \
-        Certificate, Finished, HelloMessage, ChangeCipherSpec, NextProtocol
+        Certificate, Finished, HelloMessage, ChangeCipherSpec, NextProtocol, \
+        ApplicationData
 from tlslite.utils.codec import Parser
 from tlslite.constants import CipherSuite, CertificateType, ContentType, \
         AlertLevel, AlertDescription, ExtensionType, ClientCertificateType, \
@@ -2852,6 +2853,43 @@ class TestNextProtocol(unittest.TestCase):
 
         self.assertIsInstance(np, NextProtocol)
         self.assertEqual(np.next_proto, bytearray(b'test'))
+
+
+class TestApplicationData(unittest.TestCase):
+    def test___init__(self):
+        app_data = ApplicationData()
+
+        self.assertIsNotNone(app_data)
+        self.assertEqual(bytearray(0), app_data.bytes)
+
+    def test_create(self):
+        app_data = ApplicationData().create(bytearray(b'test'))
+
+        self.assertIsInstance(app_data, ApplicationData)
+        self.assertEqual(bytearray(b'test'), app_data.bytes)
+
+    def test_write(self):
+        app_data = ApplicationData().create(bytearray(b'test'))
+
+        self.assertEqual(bytearray(b'test'), app_data.write())
+
+    def test_parse(self):
+        parser = Parser(bytearray(b'test2'))
+        app_data = ApplicationData()
+
+        app_data = app_data.parse(parser)
+
+        self.assertIsInstance(app_data, ApplicationData)
+        self.assertEqual(app_data.bytes, bytearray(b'test2'))
+
+    def test_splitFirstByte(self):
+        app_data = ApplicationData().create(bytearray(b'test'))
+
+        app_data1 = app_data.splitFirstByte()
+
+        self.assertIsInstance(app_data1, ApplicationData)
+        self.assertEqual(app_data1.bytes, bytearray(b't'))
+        self.assertEqual(app_data.bytes, bytearray(b'est'))
 
 
 if __name__ == '__main__':

--- a/unit_tests/test_tlslite_messages.py
+++ b/unit_tests/test_tlslite_messages.py
@@ -842,6 +842,37 @@ class TestServerHello(unittest.TestCase):
         self.assertEqual(None, server_hello.tackExt)
         self.assertEqual(None, server_hello.next_protos_advertised)
 
+    def test_next_protos_reset(self):
+        server_hello = ServerHello().create(
+                (1,1),                          # server version
+                bytearray(b'\x00'*31+b'\x02'),  # random
+                bytearray(0),                   # session id
+                4,                              # cipher suite
+                0,                              # certificate type
+                None,                           # TACK ext
+                [bytearray(b'http/1.1')])       # next protos advertised
+
+        self.assertEqual(server_hello.next_protos, [bytearray(b'http/1.1')])
+        server_hello.next_protos = [bytearray(b'spdy/3'),
+                                    bytearray(b'http/1.1')]
+        self.assertEqual([bytearray(b'spdy/3'), bytearray(b'http/1.1')],
+                         server_hello.next_protos)
+
+    @unittest.expectedFailure
+    def test_next_protos_reset_to_None(self):
+        server_hello = ServerHello().create(
+                (1,1),                          # server version
+                bytearray(b'\x00'*31+b'\x02'),  # random
+                bytearray(0),                   # session id
+                4,                              # cipher suite
+                0,                              # certificate type
+                None,                           # TACK ext
+                [bytearray(b'http/1.1')])       # next protos advertised
+
+        self.assertEqual(server_hello.next_protos, [bytearray(b'http/1.1')])
+        server_hello.next_protos = None
+        self.assertIsNone(server_hello.next_protos)
+
     def test_certificate_type_update_to_x509(self):
         server_hello = ServerHello().create(
                 (1,1),                          # server version

--- a/unit_tests/test_tlslite_messages.py
+++ b/unit_tests/test_tlslite_messages.py
@@ -854,6 +854,20 @@ class TestServerHello(unittest.TestCase):
         server_hello.certificate_type = CertificateType.x509
         self.assertEqual(CertificateType.x509, server_hello.certificate_type)
 
+    def test_certificate_type_set_to_raw(self):
+        server_hello = ServerHello().create(
+                (1,1),                          # server version
+                bytearray(b'\x00'*31+b'\x01'),  # random
+                bytearray(0),                   # session id
+                4,                              # cipher suite
+                1,                              # certificate type
+                None,                           # TACK ext
+                None)                           # next protos advertised
+
+        server_hello.certificate_type = 2
+        self.assertEqual(2, server_hello.certificate_type)
+
+
     def test_create_with_minimal_options(self):
         server_hello = ServerHello().create(
                 (3, 3),                                 # server version

--- a/unit_tests/test_tlslite_messages.py
+++ b/unit_tests/test_tlslite_messages.py
@@ -1180,6 +1180,25 @@ class TestServerHello(unittest.TestCase):
                 "compression method(0)",
                 str(server_hello))
 
+    def test___str___with_extension(self):
+        server_hello = ServerHello()
+        server_hello = server_hello.create(
+                (3,0),
+                bytearray(b'\x00'*32),
+                bytearray(b'\x01\x20'),
+                34500,
+                0,
+                None,
+                None,
+                extensions=[SNIExtension().create(bytearray(b'test'))])
+
+        self.assertEqual("server_hello,length(55),version(3.0),random(...),"
+                "session ID(bytearray(b'\\x01 ')),cipher(0x86c4),"
+                "compression method(0),extensions[SNIExtension("
+                "serverNames=[ServerName(name_type=0, "
+                "name=bytearray(b'test'))])]",
+                str(server_hello))
+
     def test___repr__(self):
         server_hello = ServerHello()
         server_hello = server_hello.create(

--- a/unit_tests/test_tlslite_messages.py
+++ b/unit_tests/test_tlslite_messages.py
@@ -841,7 +841,6 @@ class TestServerHello(unittest.TestCase):
         self.assertEqual(None, server_hello.tackExt)
         self.assertEqual(None, server_hello.next_protos_advertised)
 
-    @unittest.expectedFailure
     def test_certificate_type_update_to_x509(self):
         server_hello = ServerHello().create(
                 (1,1),                          # server version

--- a/unit_tests/test_tlslite_messages.py
+++ b/unit_tests/test_tlslite_messages.py
@@ -841,6 +841,20 @@ class TestServerHello(unittest.TestCase):
         self.assertEqual(None, server_hello.tackExt)
         self.assertEqual(None, server_hello.next_protos_advertised)
 
+    @unittest.expectedFailure
+    def test_certificate_type_update_to_x509(self):
+        server_hello = ServerHello().create(
+                (1,1),                          # server version
+                bytearray(b'\x00'*31+b'\x01'),  # random
+                bytearray(0),                   # session id
+                4,                              # cipher suite
+                1,                              # certificate type
+                None,                           # TACK ext
+                None)                           # next protos advertised
+
+        server_hello.certificate_type = CertificateType.x509
+        self.assertEqual(CertificateType.x509, server_hello.certificate_type)
+
     def test_create_with_minimal_options(self):
         server_hello = ServerHello().create(
                 (3, 3),                                 # server version


### PR DESCRIPTION
100% test coverage for the `tlslite.messages` module, with the exception of TACK handling.
Fixing few minor bugs related to the old API handling.

<!-- Reviewable:start -->
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/tomato42/tlslite-ng/178)
<!-- Reviewable:end -->
