### PR TITLE
CI updates

### DIFF
--- a/.codeclimate.yml
+++ b/.codeclimate.yml
@@ -13,7 +13,9 @@ engines:
     - 2c398389f33ea2572edefc5370ed49c0
     config:
       languages:
-      - python
+        python:
+          python_version: 3
+          mass_threshold: 35
   fixme:
     enabled: true
     config:


### PR DESCRIPTION
Allow for larger pieces of code to be duplicate - because of the code structure necessary for generators we have fairly large amounts of false positives for duplicate code detection.

Also cause a new coverage rebuild - coverage.io now supports monitoring of branch coverage and inclusion of it in the coverage measurement, so we need to rebuild the data and get a new baseline.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/tomato42/tlslite-ng/179)
<!-- Reviewable:end -->
