### PR TITLE
Initialise CRT values when not all provided in pycrypto RSA

### DIFF
--- a/tlslite/utils/python_rsakey.py
+++ b/tlslite/utils/python_rsakey.py
@@ -14,11 +14,22 @@ class Python_RSAKey(RSAKey):
             raise AssertionError()
         self.n = n
         self.e = e
+        if p and not q or not p and q:
+            raise ValueError("p and q must be set or left unset together")
+        if not d and p and q:
+            t = lcm(p - 1, q - 1)
+            d = invMod(e, t)
         self.d = d
         self.p = p
         self.q = q
+        if not dP and p:
+            dP = d % (p - 1)
         self.dP = dP
+        if not dQ and q:
+            dQ = d % (q - 1)
         self.dQ = dQ
+        if not qInv:
+            qInv = invMod(q, p)
         self.qInv = qInv
         self.blinder = 0
         self.unblinder = 0

--- a/unit_tests/test_tlslite_utils_rsakey.py
+++ b/unit_tests/test_tlslite_utils_rsakey.py
@@ -1227,6 +1227,44 @@ class TestRSAPSS_mod2048(unittest.TestCase):
             signed = self.rsa.RSASSA_PSS_sign(mHash, 'sha512', 10)
             self.assertEqual(signed, intendedS)
 
+class TestEncryptDecrypt(unittest.TestCase):
+    n = int("a8d68acd413c5e195d5ef04e1b4faaf242365cb450196755e92e1215ba59802aa"
+            "fbadbf2564dd550956abb54f8b1c917844e5f36195d1088c600e07cada5c080ed"
+            "e679f50b3de32cf4026e514542495c54b1903768791aae9e36f082cd38e941ada"
+            "89baecada61ab0dd37ad536bcb0a0946271594836e92ab5517301d45176b5",
+            16)
+    e = int("00000000000000000000000000000000000000000000000000000000000000000"
+            "00000000000000000000000000000000000000000000000000000000000000000"
+            "00000000000000000000000000000000000000000000000000000000000000000"
+            "0000000000000000000000000000000000000000000000000000000000003",
+            16)
+    p = int("c107a2fe924b76e206cb9bc4af2ab7008547c00846bf6d0680b3eac3ebcbd0c7f"
+            "d7a54c2b9899b08f80cde1d3691eaaa2816b1eb11822d6be7beaf4e30977c49",
+            16)
+    q = int("dfea984ce4307eafc0d140c2bb82861e5dbac4f8567cbc981d70440dd63949207"
+            "9031486315e305eb83e591c4a2e96064966f7c894c3ca351925b5ce82d8ef0d",
+            16)
+    d = int("1c23c1cce034ba598f8fd2b7af37f1d30b090f7362aee68e5187adae49b9955c7"
+            "29f24a863b7a38d6e3c748e2972f6d940b7ba89043a2d6c2100256a1cf0f56a8c"
+            "d35fc6ee205244876642f6f9c3820a3d9d2c8921df7d82aaadcaf2d7334d39893"
+            "1ddbba553190b3a416099f3aa07fd5b26214645a828419e122cfb857ad73b",
+            16)
+
+    def setUp(self):
+        self.rsa = Python_RSAKey(self.n, self.e, 0, self.p, self.q)
+
+    def test_init(self):
+        self.rsa.d == self.d
+
+    def test_encDec(self):
+        self.assertEqual(bytearray(b'test'),
+                         self.rsa.decrypt(self.rsa.encrypt(bytearray(b'test')))
+                         )
+
+    def test_invalid_init(self):
+        with self.assertRaises(ValueError):
+            Python_RSAKey(self.n, self.e, self.d, self.p)
+
 
 class TestRSAPKCS1(unittest.TestCase):
     n = int("a8d68acd413c5e195d5ef04e1b4faaf242365cb450196755e92e1215ba59802aa"


### PR DESCRIPTION
For initialising the private key, only p and q are necessary.
If other values are not provided, calculate them.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/tomato42/tlslite-ng/184)
<!-- Reviewable:end -->
