### PR TITLE
TLS1.3 changes to FFDH

### DIFF
--- a/unit_tests/test_tlslite_keyexchange.py
+++ b/unit_tests/test_tlslite_keyexchange.py
@@ -1707,3 +1707,22 @@ class TestFFDHKeyExchange(unittest.TestCase):
 
         self.assertEqual(kex.generator, 2)
         self.assertEqual(kex.prime, RFC7919_GROUPS[0][1])
+
+    def test_calc_public_value(self):
+        kex = FFDHKeyExchange(GroupName.ffdhe2048, (3, 4))
+
+        private = 2
+        public = kex.calc_public_value(private)
+        # verify that numbers are zero-padded
+        self.assertEqual(public,
+                bytearray(b'\x00' * 255 + b'\x04'))
+
+    def test_calc_shared_secret(self):
+        kex = FFDHKeyExchange(GroupName.ffdhe2048, (3, 4))
+
+        private = 2
+        key_share = 4
+        shared = kex.calc_shared_key(private, key_share)
+        # verify that numbers are zero-padded on MSBs
+        self.assertEqual(shared,
+                bytearray(b'\x00' * 255 + b'\x10'))


### PR DESCRIPTION
TLS 1.3 requires that both the public value and the shared value to
be left-padded with zeros to the size of the prime used as the group

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/tomato42/tlslite-ng/193)
<!-- Reviewable:end -->
