### PR TITLE
ECDSA support

### DIFF
--- a/tlslite/handshakesettings.py
+++ b/tlslite/handshakesettings.py
@@ -530,6 +530,7 @@ class HandshakeSettings(object):
         """Copy values of settings related to extensions."""
         other.useExtendedMasterSecret = self.useExtendedMasterSecret
         other.requireExtendedMasterSecret = self.requireExtendedMasterSecret
+        other.useExperimentalTackExtension = self.useExperimentalTackExtension
         other.sendFallbackSCSV = self.sendFallbackSCSV
         other.useEncryptThenMAC = self.useEncryptThenMAC
         other.usePaddingExtension = self.usePaddingExtension

--- a/tlslite/tlsconnection.py
+++ b/tlslite/tlsconnection.py
@@ -2013,8 +2013,12 @@ class TLSConnection(TLSRecordLayer):
 
         self._handshakeStart(client=False)
 
+        if not settings:
+            settings = HandshakeSettings()
+        settings = settings.validate()
+
         if (not verifierDB) and (not cert_chain) and not anon and \
-                not settings.pskConfigs:
+                not settings.pskConfigs and not settings.virtual_hosts:
             raise ValueError("Caller passed no authentication credentials")
         if cert_chain and not privateKey:
             raise ValueError("Caller passed a cert_chain but no privateKey")
@@ -2029,14 +2033,11 @@ class TLSConnection(TLSRecordLayer):
         if tacks:
             if not tackpyLoaded:
                 raise ValueError("tackpy is not loaded")
-            if not settings or not settings.useExperimentalTackExtension:
+            if not settings.useExperimentalTackExtension:
                 raise ValueError("useExperimentalTackExtension not enabled")
         if alpn is not None and not alpn:
             raise ValueError("Empty list of ALPN protocols")
 
-        if not settings:
-            settings = HandshakeSettings()
-        settings = settings.validate()
         self.sock.padding_cb = settings.padding_cb
 
         # OK Start exchanging messages

--- a/tlslite/tlsconnection.py
+++ b/tlslite/tlsconnection.py
@@ -1910,11 +1910,13 @@ class TLSConnection(TLSRecordLayer):
 
         :type certChain: ~tlslite.x509certchain.X509CertChain
         :param certChain: The certificate chain to be used if the
-            client requests server certificate authentication.
+            client requests server certificate authentication and no virtual
+            host defined in HandshakeSettings matches ClientHello.
 
         :type privateKey: ~tlslite.utils.rsakey.RSAKey
         :param privateKey: The private key to be used if the client
-            requests server certificate authentication.
+            requests server certificate authentication and no virtual host
+            defined in HandshakeSettings matches ClientHello.
 
         :type reqCert: bool
         :param reqCert: Whether to request client certificate
@@ -1941,21 +1943,23 @@ class TLSConnection(TLSRecordLayer):
 
         :type reqCAs: list of bytearray
         :param reqCAs: A collection of DER-encoded DistinguishedNames that
-            will be sent along with a certificate request. This does not affect
-            verification.
+            will be sent along with a certificate request to help client pick
+            a certificates. This does not affect verification.
 
         :type nextProtos: list of str
         :param nextProtos: A list of upper layer protocols to expose to the
             clients through the Next-Protocol Negotiation Extension,
-            if they support it.
+            if they support it. Deprecated, use the `virtual_hosts` in
+            HandshakeSettings.
 
         :type alpn: list of bytearray
         :param alpn: names of application layer protocols supported.
             Note that it will be used instead of NPN if both were advertised by
-            client.
+            client. Deprecated, use the `virtual_hosts` in HandshakeSettings.
 
         :type sni: bytearray
-        :param sni: expected virtual name hostname.
+        :param sni: expected virtual name hostname. Deprecated, use the
+            `virtual_hosts` in HandshakeSettings.
 
         :raises socket.error: If a socket error occurs.
         :raises tlslite.errors.TLSAbruptCloseError: If the socket is closed

--- a/tlslite/x509.py
+++ b/tlslite/x509.py
@@ -42,6 +42,22 @@ class X509(object):
         self.subject = None
         self.certAlg = None
 
+    def __hash__(self):
+        """Calculate hash of object."""
+        return hash(bytes(self.bytes))
+
+    def __eq__(self, other):
+        """Compare other object for equality."""
+        if not hasattr(other, "bytes"):
+            return NotImplemented
+        return self.bytes == other.bytes
+
+    def __ne__(self, other):
+        """Compare with other object for inequality."""
+        if not hasattr(other, "bytes"):
+            return NotImplemented
+        return not self == other
+
     def parse(self, s):
         """
         Parse a PEM-encoded X.509 certificate.

--- a/tlslite/x509certchain.py
+++ b/tlslite/x509certchain.py
@@ -30,6 +30,22 @@ class X509CertChain(object):
         else:
             self.x509List = []
 
+    def __hash__(self):
+        """Return hash of the object."""
+        return hash(tuple(self.x509List))
+
+    def __eq__(self, other):
+        """Compare objects with each-other."""
+        if not hasattr(other, "x509List"):
+            return NotImplemented
+        return self.x509List == other.x509List
+
+    def __ne__(self, other):
+        """Compare object for inequality."""
+        if not hasattr(other, "x509List"):
+            return NotImplemented
+        return self.x509List != other.x509List
+
     def parsePemList(self, s):
         """Parse a string containing a sequence of PEM certs.
 

--- a/unit_tests/test_tlslite_x509.py
+++ b/unit_tests/test_tlslite_x509.py
@@ -12,10 +12,12 @@ except ImportError:
 
 from tlslite.x509 import X509
 from tlslite.utils.python_ecdsakey import Python_ECDSAKey
+from tlslite.x509certchain import X509CertChain
 
 class TestX509(unittest.TestCase):
-    def test_pem(self):
-        data = (
+    @classmethod
+    def setUpClass(cls):
+        cls.data = (
             "-----BEGIN CERTIFICATE-----\n"
             "MIIBbTCCARSgAwIBAgIJAPM58cskyK+yMAkGByqGSM49BAEwFDESMBAGA1UEAwwJ\n"
             "bG9jYWxob3N0MB4XDTE3MTAyMzExNDI0MVoXDTE3MTEyMjExNDI0MVowFDESMBAG\n"
@@ -26,8 +28,10 @@ class TestX509(unittest.TestCase):
             "KoZIzj0EAQNIADBFAiA6p0YM5ZzfW+klHPRU2r13/IfKgeRfDR3dtBngmPvxUgIh\n"
             "APTeSDeJvYWVBLzyrKTeSerNDKKHU2Rt7sufipv76+7s\n"
             "-----END CERTIFICATE-----\n")
+
+    def test_pem(self):
         x509 = X509()
-        x509.parse(data)
+        x509.parse(self.data)
 
         self.assertIsNotNone(x509.publicKey)
         self.assertIsInstance(x509.publicKey, Python_ECDSAKey)
@@ -37,3 +41,42 @@ class TestX509(unittest.TestCase):
             12490546948316647166662676770106859255378658810545502161335656899238893361610)
         self.assertEqual(x509.publicKey.curve_name, "NIST256p")
 
+    def test_hash(self):
+        x509_1 = X509()
+        x509_1.parse(self.data)
+
+        x509_2 = X509()
+        x509_2.parse(self.data)
+
+        self.assertEqual(hash(x509_1), hash(x509_2))
+        self.assertEqual(x509_1, x509_2)
+
+
+class TestX509CertChain(unittest.TestCase):
+    @classmethod
+    def setUpClass(cls):
+        cls.data = (
+            "-----BEGIN CERTIFICATE-----\n"
+            "MIIBbTCCARSgAwIBAgIJAPM58cskyK+yMAkGByqGSM49BAEwFDESMBAGA1UEAwwJ\n"
+            "bG9jYWxob3N0MB4XDTE3MTAyMzExNDI0MVoXDTE3MTEyMjExNDI0MVowFDESMBAG\n"
+            "A1UEAwwJbG9jYWxob3N0MFkwEwYHKoZIzj0CAQYIKoZIzj0DAQcDQgAEyDRjEAJe\n"
+            "3F5T62MyZbhjoJnPLGL2nrTthLFymBupZ2IbnWYnqVWDkT/L6i8sQhf2zCLrlSjj\n"
+            "1kn7ERqPx/KZyqNQME4wHQYDVR0OBBYEFPfFTUg9o3t6ehLsschSnC8Te8oaMB8G\n"
+            "A1UdIwQYMBaAFPfFTUg9o3t6ehLsschSnC8Te8oaMAwGA1UdEwQFMAMBAf8wCQYH\n"
+            "KoZIzj0EAQNIADBFAiA6p0YM5ZzfW+klHPRU2r13/IfKgeRfDR3dtBngmPvxUgIh\n"
+            "APTeSDeJvYWVBLzyrKTeSerNDKKHU2Rt7sufipv76+7s\n"
+            "-----END CERTIFICATE-----\n")
+
+    def test_pem(self):
+        x509cc = X509CertChain()
+        x509cc.parsePemList(self.data)
+
+    def test_hash(self):
+        x509cc1 = X509CertChain()
+        x509cc1.parsePemList(self.data)
+
+        x509cc2 = X509CertChain()
+        x509cc2.parsePemList(self.data)
+
+        self.assertEqual(hash(x509cc1), hash(x509cc2))
+        self.assertEqual(x509cc1, x509cc2)


### PR DESCRIPTION
 - [x] parsing ECDSA certificates
 - [x] verifying ECDSA signatures on Server Key Exchange
 - [x] negotiating ECDSA ciphers as a client
 - [x] loading private keys
 - [x] signing Server Key Exchange messages with ECDSA
 - [x] negotiating ECDSA ciphers as a server
 - [x] handling ECDSA in Certificate Verify (as client and server)
 - [x] handling ECDSA in TLS 1.1 and earlier (signatures use SHA1, not SHA1+MD5)
 - [ ] using m2crypto for ECDSA (can be moved to a separate issue, should autodetect if the version of m2crypto/openssl does support ECC)
    - moved to #367
 - [x] verify that sha1+ecdsa is selected if client didn't advertise signature algorithms but did advertise ecdsa ciphersuites in TLSv1.2
 - [x] verify that sha1+ecdsa and sha224+ecdsa is ignored for signature algorithms in TLS 1.3 (it's disallowed there)
 - [x] select signature algorithm based on public key type in TLS 1.3 (sha256 can be used with P-256 only, etc.)
 - [ ] support for starting server with multiple certificates/keys and selecting good one based on client preference, supported cipher suites or signature algorithms
    -  (partially: see #366)
 - [x] verify that server advertised support for `ecdsa_sign` in CertificateRequest (or `rsa_sign` if we have a RSA certificate)
 - [x] test coverage for all of the above

fixes #52 

merged as #359,  #360, #361, #363

------------------

<!-- Reviewable:start -->
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/tomato42/tlslite-ng/196)
<!-- Reviewable:end -->
