### PR TITLE
restore API compatibility for RecordLayer

### DIFF
--- a/tlslite/tlsrecordlayer.py
+++ b/tlslite/tlsrecordlayer.py
@@ -177,6 +177,8 @@ class TLSRecordLayer(object):
         protocol version.
         """
         self._recordLayer.version = value
+        if value > (3, 3):
+            self._recordLayer.tls13record = True
 
     @property
     def encryptThenMAC(self):

--- a/unit_tests/test_tlslite_recordlayer.py
+++ b/unit_tests/test_tlslite_recordlayer.py
@@ -526,6 +526,7 @@ class TestRecordLayer(unittest.TestCase):
 
         recordLayer = RecordLayer(sock)
         recordLayer.version = (3, 4)
+        recordLayer.tls13record = True
 
         recordLayer.calcTLS1_3PendingState(CipherSuite.TLS_AES_128_GCM_SHA256,
                                            bytearray(32),  # cl_traffic_sec
@@ -568,6 +569,7 @@ class TestRecordLayer(unittest.TestCase):
         recordLayer = RecordLayer(sock)
         recordLayer.client = False
         recordLayer.version = (3, 4)
+        recordLayer.tls13record = True
 
         recordLayer.calcTLS1_3PendingState(CipherSuite.TLS_AES_128_GCM_SHA256,
                                            bytearray(32),  # cl_traffic_sec
@@ -598,6 +600,7 @@ class TestRecordLayer(unittest.TestCase):
 
         recordLayer = RecordLayer(sock)
         recordLayer.version = (3, 4)
+        recordLayer.tls13record = True
 
         recordLayer.calcTLS1_3PendingState(CipherSuite.TLS_AES_256_GCM_SHA384,
                                            bytearray(48),  # cl_traffic_sec
@@ -632,6 +635,7 @@ class TestRecordLayer(unittest.TestCase):
 
         recordLayer = RecordLayer(sock)
         recordLayer.version = (3, 4)
+        recordLayer.tls13record = True
 
         ciph = CipherSuite.TLS_CHACHA20_POLY1305_SHA256
         recordLayer.calcTLS1_3PendingState(ciph,
@@ -668,6 +672,7 @@ class TestRecordLayer(unittest.TestCase):
 
         recordLayer = RecordLayer(sock)
         recordLayer.version = (3, 4)
+        recordLayer.tls13record = True
         self.assertEqual((3, 4), recordLayer.version)
 
         recordLayer.calcTLS1_3PendingState(CipherSuite.TLS_AES_128_GCM_SHA256,
@@ -699,6 +704,7 @@ class TestRecordLayer(unittest.TestCase):
         sock = MockSocket(sock.sent[0])
         recordLayer = RecordLayer(sock)
         recordLayer.version = (3, 4)
+        recordLayer.tls13record = True
         recordLayer.client = False
 
         recordLayer.calcTLS1_3PendingState(CipherSuite.TLS_AES_128_GCM_SHA256,


### PR DESCRIPTION
Because tools like tlsfuzzer need to be able to send records with
arbitrary versions, without hiding content type, we need to restore
the API compatibility, in that if just the .version is set to high
values (3, 5), (3, 255), etc. the record layer behaves the same as it
did in TLS 1.2 and earlier

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/tomato42/tlslite-ng/197)
<!-- Reviewable:end -->
