### PR TITLE
disable Nagle algorithm in example script

### DIFF
--- a/scripts/tls.py
+++ b/scripts/tls.py
@@ -278,6 +278,7 @@ def clientCmd(argv):
     sock = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
     sock.settimeout(5)
     sock.connect(address)
+    sock.setsockopt(socket.IPPROTO_TCP, socket.TCP_NODELAY, 1)
     connection = TLSConnection(sock)
     
     settings = HandshakeSettings()
@@ -368,6 +369,8 @@ def serverCmd(argv):
                 settings = HandshakeSettings()
                 settings.useExperimentalTackExtension=True
                 settings.dhParams = dhparam
+                connection.setsockopt(socket.IPPROTO_TCP, socket.TCP_NODELAY,
+                                      1)
                 connection.handshakeServer(certChain=certChain,
                                               privateKey=privateKey,
                                               verifierDB=verifierDB,


### PR DESCRIPTION
since caching and fragmentation is done on record
layer anyway, doing it on TCP level just screws with
alert delivery

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/tomato42/tlslite-ng/199)
<!-- Reviewable:end -->
