### PR TITLE
make setting the encryptThenMAC apply since next cipher change

### DIFF
--- a/unit_tests/test_tlslite_recordlayer.py
+++ b/unit_tests/test_tlslite_recordlayer.py
@@ -2425,6 +2425,7 @@ class TestRecordLayer(unittest.TestCase):
                 bytearray(32), # server random
                 None)
         sendingRecordLayer.changeWriteState()
+        self.assertTrue(sendingRecordLayer.encryptThenMAC)
 
         msg = ApplicationData().create(bytearray(b'test'))
 


### PR DESCRIPTION
as the method of encrypting applies to the cipher, not
the connection or session, it needs to be kept together
with the cipher settings for a specific connection direction

fixes issue with EtM negotiation in renegotiation case

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/tomato42/tlslite-ng/201)
<!-- Reviewable:end -->
