### PR TITLE
Python3 m2crypto

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -38,7 +38,12 @@ matrix:
       env: TACKPY=true
     - python: 2.7
       env: M2CRYPTO=true
-# no M2crypto on Python 3
+    - python: 3.4
+      env: M2CRYPTO=true
+    - python: 3.5
+      env: M2CRYPTO=true
+    - python: 3.6
+      env: M2CRYPTO=true
     - python: 2.7
       env: PYCRYPTO=true
     - python: 3.4
@@ -58,11 +63,11 @@ matrix:
     - python: 2.7
       env: M2CRYPTO=true PYCRYPTO=true GMPY=true
     - python: 3.4
-      env: PYCRYPTO=true GMPY=true
+      env: M2CRYPTO=true PYCRYPTO=true GMPY=true
     - python: 3.5
-      env: PYCRYPTO=true GMPY=true
+      env: M2CRYPTO=true PYCRYPTO=true GMPY=true
     - python: 3.6
-      env: PYCRYPTO=true GMPY=true
+      env: M2CRYPTO=true PYCRYPTO=true GMPY=true
 
 before_install:
   - |

--- a/tlslite/utils/compat.py
+++ b/tlslite/utils/compat.py
@@ -20,7 +20,13 @@ if sys.version_info >= (3,0):
     # So, python 2.6 requires strings, python 3 requires 'bytes',
     # and python 2.7 can handle bytearrays...     
     def compatHMAC(x): return bytes(x)
-    
+
+    def compatAscii2Bytes(val):
+        """Convert ASCII string to bytes."""
+        if isinstance(val, str):
+            return bytes(val, 'ascii')
+        return val
+
     def raw_input(s):
         return input(s)
     
@@ -72,6 +78,10 @@ else:
         def compat26Str(x): return str(x)
     else:
         def compat26Str(x): return x
+
+    def compatAscii2Bytes(val):
+        """Convert ASCII string to bytes."""
+        return val
 
     # So, python 2.6 requires strings, python 3 requires 'bytes',
     # and python 2.7 can handle bytearrays...     

--- a/tlslite/utils/cryptomath.py
+++ b/tlslite/utils/cryptomath.py
@@ -201,11 +201,14 @@ def numberToByteArray(n, howManyBytes=None, endian="big"):
     else:
         raise ValueError("Only 'big' and 'little' endian supported")
 
-def mpiToNumber(mpi): #mpi is an openssl-format bignum string
-    if (ord(mpi[4]) & 0x80) !=0: #Make sure this is a positive number
-        raise AssertionError()
-    b = bytearray(mpi[4:])
-    return bytesToNumber(b)
+
+def mpiToNumber(mpi):
+    """Convert a MPI (OpenSSL bignum string) to an integer."""
+    byte = bytearray(mpi)
+    if byte[4] & 0x80:
+        raise ValueError("Input must be a positive integer")
+    return bytesToNumber(byte[4:])
+
 
 def numberToMPI(n):
     b = numberToByteArray(n)

--- a/tlslite/utils/openssl_aes.py
+++ b/tlslite/utils/openssl_aes.py
@@ -42,7 +42,7 @@ if m2cryptoLoaded:
             context = self._createContext(0)
             #I think M2Crypto has a bug - it fails to decrypt and return the last block passed in.
             #To work around this, we append sixteen zeros to the string, below:
-            plaintext = m2.cipher_update(context, ciphertext+('\0'*16))
+            plaintext = m2.cipher_update(context, ciphertext+(b'\0'*16))
 
             #If this bug is ever fixed, then plaintext will end up having a garbage
             #plaintext block on the end.  That's okay - the below code will discard it.

--- a/tlslite/utils/openssl_rsakey.py
+++ b/tlslite/utils/openssl_rsakey.py
@@ -7,6 +7,7 @@ from .cryptomath import *
 
 from .rsakey import *
 from .python_rsakey import Python_RSAKey
+from .compat import compatAscii2Bytes
 
 #copied from M2Crypto.util.py, so when we load the local copy of m2
 #we can still use it
@@ -112,7 +113,7 @@ if m2cryptoLoaded:
                     callback = f
                 bio = m2.bio_new(m2.bio_s_mem())
                 try:
-                    m2.bio_write(bio, s)
+                    m2.bio_write(bio, compatAscii2Bytes(s))
                     key = OpenSSL_RSAKey()
                     # parse SSLay format PEM file
                     if s.startswith("-----BEGIN RSA PRIVATE KEY-----"):

--- a/tlslite/utils/openssl_tripledes.py
+++ b/tlslite/utils/openssl_tripledes.py
@@ -37,7 +37,7 @@ if m2cryptoLoaded:
             context = self._createContext(0)
             #I think M2Crypto has a bug - it fails to decrypt and return the last block passed in.
             #To work around this, we append sixteen zeros to the string, below:
-            plaintext = m2.cipher_update(context, ciphertext+('\0'*16))
+            plaintext = m2.cipher_update(context, ciphertext+(b'\0'*16))
 
             #If this bug is ever fixed, then plaintext will end up having a garbage
             #plaintext block on the end.  That's okay - the below code will ignore it.

--- a/unit_tests/test_tlslite_utils_cryptomath.py
+++ b/unit_tests/test_tlslite_utils_cryptomath.py
@@ -16,7 +16,7 @@ import struct
 from tlslite.utils.cryptomath import isPrime, numBits, numBytes, \
         numberToByteArray, MD5, SHA1, secureHash, HMAC_MD5, HMAC_SHA1, \
         HMAC_SHA256, HMAC_SHA384, HKDF_expand, bytesToNumber, \
-        HKDF_expand_label, derive_secret
+        HKDF_expand_label, derive_secret, numberToMPI, mpiToNumber
 from tlslite.handshakehashes import HandshakeHashes
 
 class TestIsPrime(unittest.TestCase):
@@ -504,3 +504,17 @@ class TestDerive_secret(unittest.TestCase):
                          bytearray(b'\t\xec\x01W[Y\xdcP\xac\xebu\x13\xe6\x98'
                                    b'\x19\xccu;\xfa\x90\xc9\xe3\xc1\xe7\xb7'
                                    b'\xcf\x0c\x97;x\xf0F'))
+
+
+class TestMPI(unittest.TestCase):
+    def test_toMPI(self):
+        r = numberToMPI(200)
+        self.assertEqual(bytearray(b'\x00\x00\x00\x02\x00\xc8'), r)
+
+    def test_fromMPI(self):
+        r = mpiToNumber(bytearray(b'\x00\x00\x00\x02\x00\xc8'))
+        self.assertEqual(r, 200)
+
+    def test_fromMPI_with_negative_number(self):
+        with self.assertRaises(ValueError):
+            mpiToNumber(bytearray(b'\x00\x00\x00\x01\xc8'))

--- a/unit_tests/test_tlslite_utils_keyfactory.py
+++ b/unit_tests/test_tlslite_utils_keyfactory.py
@@ -2,6 +2,7 @@
 #
 # See the LICENSE file for legal information regarding use of this file.
 
+import sys
 # compatibility with Python 2.6, for that we need unittest2 package,
 # which is not available on 3.3 or 3.4
 try:
@@ -12,6 +13,9 @@ except ImportError:
 from tlslite.utils.keyfactory import parsePEMKey
 from tlslite.utils.rsakey import RSAKey
 from tlslite.utils import cryptomath
+
+if cryptomath.m2cryptoLoaded:
+    import M2Crypto
 
 class TestParsePEMKey(unittest.TestCase):
 
@@ -168,7 +172,12 @@ class TestParsePEMKey(unittest.TestCase):
     def test_key_parse_using_openssl(self):
 
         # XXX doesn't handle files without newlines
-        with self.assertRaises(SyntaxError):
+        # old version of M2Crypto return a Null, in Python3 it raises exception
+        if M2Crypto.version_info > (0, 27):
+            exp = M2Crypto.EVP.EVPError
+        else:
+            exp = SyntaxError
+        with self.assertRaises(exp):
             key = parsePEMKey(self.privKey_str,
                     private=True,
                     implementations=["openssl"])


### PR DESCRIPTION
Since M2Crypto now supports Python3, test with it installed, also fix few minor issues related to that change

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/tomato42/tlslite-ng/204)
<!-- Reviewable:end -->
