### PR TITLE
Fixes for python 3.7 support

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -23,6 +23,7 @@ python:
   - 3.4
   - 3.5
   - 3.6
+  - 3.7-dev
 
 env:
   - TACKPY=true
@@ -52,6 +53,8 @@ matrix:
       env: PYCRYPTO=true
     - python: 3.6
       env: PYCRYPTO=true
+    - python: 3.7-dev
+      env: PYCRYPTO=true
     - python: 2.7
       env: GMPY=true
     - python: 3.4
@@ -67,6 +70,8 @@ matrix:
     - python: 3.5
       env: M2CRYPTO=true PYCRYPTO=true GMPY=true
     - python: 3.6
+      env: M2CRYPTO=true PYCRYPTO=true GMPY=true
+    - python: 3.7-dev
       env: M2CRYPTO=true PYCRYPTO=true GMPY=true
 
 before_install:

--- a/setup.py
+++ b/setup.py
@@ -37,6 +37,7 @@ setup(name="tlslite-ng",
             'Programming Language :: Python :: 3.4',
             'Programming Language :: Python :: 3.5',
             'Programming Language :: Python :: 3.6',
+            'Programming Language :: Python :: 3.7',
             'Topic :: Security :: Cryptography',
             'Topic :: Software Development :: Libraries :: Python Modules',
             'Topic :: System :: Networking'

--- a/tlslite/integration/asyncstatemachine.py
+++ b/tlslite/integration/asyncstatemachine.py
@@ -197,7 +197,7 @@ class AsyncStateMachine:
         :param generator handshaker: A generator created by using one of the
             asynchronous handshake functions (i.e.
             :py:meth:`~.TLSConnection.handshakeServerAsync` , or
-            handshakeClientxxx(..., async=True).
+            handshakeClientxxx(..., async_=True).
         """
         try:
             self._checkAssert(0)

--- a/tlslite/tlsconnection.py
+++ b/tlslite/tlsconnection.py
@@ -109,7 +109,7 @@ class TLSConnection(TLSRecordLayer):
 
     def handshakeClientAnonymous(self, session=None, settings=None,
                                  checker=None, serverName=None,
-                                 async=False):
+                                 async_=False):
         """Perform an anonymous handshake in the role of client.
 
         This function performs an SSL or TLS handshake using an
@@ -144,7 +144,7 @@ class TLSConnection(TLSRecordLayer):
         :param serverName: The ServerNameIndication TLS Extension.
 
         :type async: bool
-        :param async: If False, this function will block until the
+        :param async_: If False, this function will block until the
             handshake is completed.  If True, this function will return a
             generator.  Successive invocations of the generator will
             return 0 if it is waiting to read from the socket, 1 if it is
@@ -175,7 +175,7 @@ class TLSConnection(TLSRecordLayer):
     def handshakeClientSRP(self, username, password, session=None,
                            settings=None, checker=None,
                            reqTack=True, serverName=None,
-                           async=False):
+                           async_=False):
         """Perform an SRP handshake in the role of client.
 
         This function performs a TLS/SRP handshake.  SRP mutually
@@ -221,7 +221,7 @@ class TLSConnection(TLSRecordLayer):
         :param serverName: The ServerNameIndication TLS Extension.
 
         :type async: bool
-        :param async: If False, this function will block until the
+        :param async_: If False, this function will block until the
             handshake is completed.  If True, this function will return a
             generator.  Successive invocations of the generator will
             return 0 if it is waiting to read from the socket, 1 if it is
@@ -262,7 +262,7 @@ class TLSConnection(TLSRecordLayer):
     def handshakeClientCert(self, certChain=None, privateKey=None,
                             session=None, settings=None, checker=None,
                             nextProtos=None, reqTack=True, serverName=None,
-                            async=False, alpn=None):
+                            async_=False, alpn=None):
         """Perform a certificate-based handshake in the role of client.
 
         This function performs an SSL or TLS handshake.  The server
@@ -320,7 +320,7 @@ class TLSConnection(TLSRecordLayer):
         :param serverName: The ServerNameIndication TLS Extension.
 
         :type async: bool
-        :param async: If False, this function will block until the
+        :param async_: If False, this function will block until the
             handshake is completed.  If True, this function will return a
             generator.  Successive invocations of the generator will
             return 0 if it is waiting to read from the socket, 1 if it is


### PR DESCRIPTION
In python 3.7, async and await are new reserved keywords which cannot
be used as variable names or arguments. This commit renames some
parameters called async to comply with that. It also updates metadata
identifiers to state python 3.7 support as well as runs with mentioned
version on travis.

Note: This is a breaking change as it renames a keyword argument to a public API method.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/tomato42/tlslite-ng/216)
<!-- Reviewable:end -->
