### PR TITLE
deprecate non-pythonic names

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -91,6 +91,7 @@ before_install:
 
 install:
   - if [[ $TRAVIS_PYTHON_VERSION == '2.6' ]]; then travis_retry pip install unittest2 'isort<4.3'; fi
+  - if [[ $TRAVIS_PYTHON_VERSION == '2.7' ]]; then travis_retry pip install unittest2; fi
   - if [[ $TACKPY == 'true' ]]; then travis_retry pip install tackpy; fi
   - if [[ $M2CRYPTO == 'true' ]]; then travis_retry pip install --pre m2crypto; fi
   - if [[ $PYCRYPTO == 'true' ]]; then travis_retry pip install pycrypto; fi

--- a/docs/tlslite.utils.deprecations.rst
+++ b/docs/tlslite.utils.deprecations.rst
@@ -1,0 +1,8 @@
+tlslite.utils.deprecations module
+=================================
+
+.. automodule:: tlslite.utils.deprecations
+    :members:
+    :special-members:
+    :undoc-members:
+    :show-inheritance:

--- a/docs/tlslite.utils.rst
+++ b/docs/tlslite.utils.rst
@@ -23,6 +23,7 @@ Submodules
    tlslite.utils.constanttime
    tlslite.utils.cryptomath
    tlslite.utils.datefuncs
+   tlslite.utils.deprecations
    tlslite.utils.dns_utils
    tlslite.utils.ecc
    tlslite.utils.keyfactory

--- a/pylintrc
+++ b/pylintrc
@@ -1,11 +1,9 @@
 [MASTER]
 
-# Specify a configuration file.
-#rcfile=
-
-# Python code to execute, usually for sys.path manipulation such as
-# pygtk.require().
-#init-hook=
+# A comma-separated list of package or module names from where C extensions may
+# be loaded. Extensions are loading into the active Python interpreter and may
+# run arbitrary code
+extension-pkg-whitelist=
 
 # Profiled execution.
 profile=no
@@ -14,26 +12,37 @@ profile=no
 # paths.
 ignore=CVS
 
-# Pickle collected data for later comparisons.
-persistent=yes
+# Add files or directories matching the regex patterns to the blacklist. The
+# regex matches against base names, not paths.
+ignore-patterns=
+
+# Python code to execute, usually for sys.path manipulation such as
+# pygtk.require().
+#init-hook=
+
+# Use multiple processes to speed up Pylint.
+jobs=1
 
 # List of plugins (as comma separated values of python modules names) to load,
 # usually to register additional checkers.
 load-plugins=
 
-# DEPRECATED
-include-ids=no
+# Pickle collected data for later comparisons.
+persistent=yes
 
-# DEPRECATED
-symbols=no
+# Specify a configuration file.
+#rcfile=
+
+# Allow loading of arbitrary C extensions. Extensions are imported into the
+# active Python interpreter and may run arbitrary code.
+unsafe-load-any-extension=no
 
 
 [MESSAGES CONTROL]
 
-# Enable the message, report, category or checker with the given id(s). You can
-# either give multiple identifier separated by comma (,) or put this option
-# multiple time. See also the "--disable" option for examples.
-#enable=
+# Only show warnings with the listed confidence levels. Leave empty to show
+# all. Valid levels: HIGH, INFERENCE, INFERENCE_FAILURE, UNDEFINED
+confidence=
 
 # Disable the message, report, category or checker with the given id(s). You
 # can either give multiple identifiers separated by comma (,) or put this
@@ -46,21 +55,18 @@ symbols=no
 # --disable=W"
 disable=locally-disabled,locally-enabled
 
+# Enable the message, report, category or checker with the given id(s). You can
+# either give multiple identifier separated by comma (,) or put this option
+# multiple time (only on the command line, not in the configuration file where
+# it should appear only once). See also the "--disable" option for examples.
+enable=
 
 [REPORTS]
-
-# Set the output format. Available formats are text, parseable, colorized, msvs
-# (visual studio) and html. You can also give a reporter class, eg
-# mypackage.mymodule.MyReporterClass.
-output-format=text
 
 # Put messages in a separate file for each module / package specified on the
 # command line instead of printing them on stdout. Reports (if any) will be
 # written in a file name "pylint_global.[txt|html]".
 files-output=no
-
-# Tells whether to display a full report or only the messages
-reports=yes
 
 # Python expression which should return a note less than 10 (10 is the highest
 # note). You have access to the variables errors warning, statement which
@@ -77,6 +83,16 @@ comment=no
 # used to format the message information. See doc for all details
 #msg-template=
 
+# Set the output format. Available formats are text, parseable, colorized, json
+# and msvs (visual studio).You can also give a reporter class, eg
+# mypackage.mymodule.MyReporterClass.
+output-format=text
+
+# Tells whether to display a full report or only the messages
+reports=yes
+
+# Activate the evaluation score.
+score=yes
 
 [LOGGING]
 
@@ -116,7 +132,7 @@ generated-members=REQUEST,acl_users,aq_parent
 bad-functions=map,filter,apply,input,file
 
 # Good variable names which should always be accepted, separated by a comma
-good-names=i,j,k,ex,Run,_
+good-names=i,j,k,e,ex,Run,_
 
 # Bad variable names which should always be refused, separated by a comma
 bad-names=foo,bar,baz,toto,tutu,tata
@@ -129,17 +145,13 @@ name-group=
 include-naming-hint=no
 
 # Regular expression matching correct function names
-#function-rgx=[a-z_][a-z0-9_]{2,30}$
-# mixedCase
-function-rgx=_?[a-z][A-Za-z0-9]{1,30}$
+function-rgx=(([a-z][a-z0-9_]{2,30})|(_[a-z0-9_]*))$
 
 # Naming hint for function names
 function-name-hint=[a-z_][a-z0-9_]{2,30}$
 
 # Regular expression matching correct variable names
-#variable-rgx=[a-z_][a-z0-9_]{2,30}$
-# mixedCase
-variable-rgx=_?[a-z][A-Za-z0-9]{1,30}$
+variable-rgx=(([a-z][a-z0-9_]{2,30})|(_[a-z0-9_]*))$
 
 # Naming hint for variable names
 variable-name-hint=[a-z_][a-z0-9_]{2,30}$
@@ -151,20 +163,16 @@ const-rgx=(([A-Z_][A-Z0-9_]*)|(__.*__))$
 const-name-hint=(([A-Z_][A-Z0-9_]*)|(__.*__))$
 
 # Regular expression matching correct attribute names
-#attr-rgx=[a-z_][a-z0-9_]{2,30}$
-# mixedCase
-attr-rgx=_?[a-z][A-Za-z0-9]{1,30}$
+attr-rgx=(([a-z][a-z0-9_]{2,30})|(_[a-z0-9_]*))$
 
 # Naming hint for attribute names
-attr-name-hint=[a-z_][a-z0-9_]{2,30}$
+attr-name-hint=(([a-z][a-z0-9_]{2,30})|(_[a-z0-9_]*))$
 
 # Regular expression matching correct argument names
-#argument-rgx=[a-z_][a-z0-9_]{2,30}$
-# mixedCase or _mixedCase
-argument-rgx=_?[a-z][A-Za-z0-9]{1,30}$
+argument-rgx=(([a-z][a-z0-9_]{2,30})|(_[a-z0-9_]*))$
 
 # Naming hint for argument names
-argument-name-hint=[a-z_][a-z0-9_]{2,30}$
+argument-name-hint=(([a-z][a-z0-9_]{2,30})|(_[a-z0-9_]*))$
 
 # Regular expression matching correct class attribute names
 class-attribute-rgx=([A-Za-z_][A-Za-z0-9_]{2,30}|(__.*__))$
@@ -173,9 +181,7 @@ class-attribute-rgx=([A-Za-z_][A-Za-z0-9_]{2,30}|(__.*__))$
 class-attribute-name-hint=([A-Za-z_][A-Za-z0-9_]{2,30}|(__.*__))$
 
 # Regular expression matching correct inline iteration names
-#inlinevar-rgx=[A-Za-z_][A-Za-z0-9_]*$
-# mixedCase
-inlinevar-rgx=_?[a-z][A-Za-z0-9]{1,30}$
+inlinevar-rgx=[A-Za-z_][A-Za-z0-9_]*$
 
 # Naming hint for inline iteration names
 inlinevar-name-hint=[A-Za-z_][A-Za-z0-9_]*$
@@ -193,9 +199,7 @@ module-rgx=(([a-z_][a-z0-9_]*)|([A-Z][a-zA-Z0-9]+))$
 module-name-hint=(([a-z_][a-z0-9_]*)|([A-Z][a-zA-Z0-9]+))$
 
 # Regular expression matching correct method names
-#method-rgx=[a-z_][a-z0-9_]{2,30}$
-# mixedCase
-method-rgx=((_?[a-z][A-Za-z0-9]{1,30})|(__.*__))$
+method-rgx=(([a-z][a-z0-9_]{2,30})|(_[a-z0-9_]*))$
 
 # Naming hint for method names
 method-name-hint=[a-z_][a-z0-9_]{2,30}$

--- a/tlslite/utils/deprecations.py
+++ b/tlslite/utils/deprecations.py
@@ -1,12 +1,16 @@
-
+# Copyright (c) 2018 Hubert Kario
+#
+# See the LICENSE file for legal information regarding use of this file.
+"""Methods for deprecating old names for arguments or attributes."""
 import warnings
 from functools import wraps
+
 
 def deprecated_params(names, warn="Param name '{old_name}' is deprecated, "
                                   "please use '{new_name}'"):
     """Decorator to translate obsolete names and warn about their use.
 
-    :param dict names: dictionary with pairs of new_name: old_name pairs
+    :param dict names: dictionary with pairs of new_name: old_name
         that will be used for translating obsolete param names to new names
 
     :param str warn: DeprecationWarning format string for informing the user
@@ -31,3 +35,110 @@ def deprecated_params(names, warn="Param name '{old_name}' is deprecated, "
         return wrapper
     return decorator
 
+
+def deprecated_instance_attrs(names,
+                              warn="Attribute '{old_name}' is deprecated, "
+                                   "please use '{new_name}'"):
+    """Decorator to deprecate class instance attributes.
+
+    Translates all names in `names` to use new names and emits warnings
+    if the translation was necessary. Does apply only to instance variables
+    and attributes (won't modify behaviour of class variables, static methods,
+    etc.
+
+    :param dict names: dictionary with paris of new_name: old_name that will
+        be used to translate the calls
+    :param str warn: DeprecationWarning format string for informing the user
+        what is the current parameter name, uses 'old_name' for the
+        deprecated keyword name and 'new_name' for the current one.
+        Example: "Old name: {old_name}, use {new_name} instead".
+    """
+    # reverse the dict as we're looking for old attributes, not new ones
+    names = dict((j, i) for i, j in names.items())
+
+    def decorator(clazz):
+        def getx(self, name, __old_getx=getattr(clazz, "__getattr__", None)):
+            if name in names:
+                warnings.warn(warn.format(old_name=name,
+                                          new_name=names[name]),
+                              DeprecationWarning,
+                              stacklevel=2)
+                return getattr(self, names[name])
+            if __old_getx:
+                if hasattr(__old_getx, "__func__"):
+                    return __old_getx.__func__(self, name)
+                return __old_getx(self, name)
+            raise AttributeError("'{0}' object has no attribute '{1}'"
+                                 .format(clazz.__name__, name))
+
+        getx.__name__ = "__getattr__"
+        clazz.__getattr__ = getx
+
+        def setx(self, name, value, __old_setx=getattr(clazz, "__setattr__")):
+            if name in names:
+                warnings.warn(warn.format(old_name=name,
+                                          new_name=names[name]),
+                              DeprecationWarning,
+                              stacklevel=2)
+                setattr(self, names[name], value)
+            else:
+                __old_setx(self, name, value)
+
+        setx.__name__ = "__setattr__"
+        clazz.__setattr__ = setx
+
+        def delx(self, name, __old_delx=getattr(clazz, "__delattr__")):
+            if name in names:
+                warnings.warn(warn.format(old_name=name,
+                                          new_name=names[name]),
+                              DeprecationWarning,
+                              stacklevel=2)
+                delattr(self, names[name])
+            else:
+                __old_delx(self, name)
+
+        delx.__name__ = "__delattr__"
+        clazz.__delattr__ = delx
+
+        return clazz
+    return decorator
+
+
+def deprecated_attrs(names, warn="Attribute '{old_name}' is deprecated, "
+                                 "please use '{new_name}'"):
+    """Decorator to deprecate all specified attributes in class.
+
+    Translates all names in `names` to use new names and emits warnings
+    if the translation was necessary.
+
+    Note: uses metaclass magic so is incompatible with other metaclass uses
+
+    :param dict names: dictionary with paris of new_name: old_name that will
+        be used to translate the calls
+    :param str warn: DeprecationWarning format string for informing the user
+        what is the current parameter name, uses 'old_name' for the
+        deprecated keyword name and 'new_name' for the current one.
+        Example: "Old name: {old_name}, use {new_name} instead".
+    """
+    # prepare metaclass for handling all the class methods, class variables
+    # and static methods (as they don't go through instance's __getattr__)
+    class DeprecatedProps(type):
+        pass
+
+    metaclass = deprecated_instance_attrs(names, warn)(DeprecatedProps)
+
+    def wrapper(cls):
+        cls = deprecated_instance_attrs(names, warn)(cls)
+
+        # apply metaclass
+        orig_vars = cls.__dict__.copy()
+        slots = orig_vars.get('__slots__')
+        if slots is not None:
+            if isinstance(slots, str):
+                slots = [slots]
+            for slots_var in slots:
+                orig_vars.pop(slots_var)
+        orig_vars.pop('__dict__', None)
+        orig_vars.pop('__weakref__', None)
+        return metaclass(cls.__name__, cls.__bases__, orig_vars)
+    return wrapper

--- a/tlslite/utils/deprecations.py
+++ b/tlslite/utils/deprecations.py
@@ -1,0 +1,33 @@
+
+import warnings
+from functools import wraps
+
+def deprecated_params(names, warn="Param name '{old_name}' is deprecated, "
+                                  "please use '{new_name}'"):
+    """Decorator to translate obsolete names and warn about their use.
+
+    :param dict names: dictionary with pairs of new_name: old_name pairs
+        that will be used for translating obsolete param names to new names
+
+    :param str warn: DeprecationWarning format string for informing the user
+        what is the current parameter name, uses 'old_name' for the
+        deprecated keyword name and 'new_name' for the current one.
+        Example: "Old name: {old_name}, use {new_name} instead".
+    """
+    def decorator(func):
+        @wraps(func)
+        def wrapper(*args, **kwargs):
+            for new_name, old_name in names.items():
+                if old_name in kwargs:
+                    if new_name in kwargs:
+                        raise TypeError("got multiple values for keyword "
+                                        "argument '{0}'".format(new_name))
+                    warnings.warn(warn.format(old_name=old_name,
+                                              new_name=new_name),
+                                  DeprecationWarning,
+                                  stacklevel=2)
+                    kwargs[new_name] = kwargs.pop(old_name)
+            return func(*args, **kwargs)
+        return wrapper
+    return decorator
+

--- a/unit_tests/test_tlslite_utils_deprecations.py
+++ b/unit_tests/test_tlslite_utils_deprecations.py
@@ -16,7 +16,8 @@ except ImportError:
     import unittest.mock as mock
     from unittest.mock import call
 
-from tlslite.utils.deprecations import deprecated_params
+from tlslite.utils.deprecations import deprecated_params, \
+        deprecated_attrs
 
 
 class TestDeprecatedParams(unittest.TestCase):
@@ -69,3 +70,291 @@ class TestDeprecatedParams(unittest.TestCase):
             method(param_a=a, param_b=b, older_param=c)
 
         self.assertIn('multiple values', str(e.exception))
+
+    def test_in_class(self):
+        class Clazz(object):
+            @staticmethod
+            @deprecated_params({"new_param": "old_param"})
+            def method(param, new_param=None):
+                return "{0} {1}".format(param, new_param)
+
+        instance = Clazz()
+
+        self.assertEqual(instance.method("aa", "BB"), "aa BB")
+
+        with self.assertWarns(DeprecationWarning) as e:
+            self.assertEqual(instance.method("aa", old_param="CC"), "aa CC")
+        self.assertIn("old_param", str(e.warning))
+        self.assertIn("new_param", str(e.warning))
+
+        with self.assertWarns(DeprecationWarning) as e:
+            self.assertEqual(Clazz.method("g", old_param="D"), "g D")
+        self.assertIn("old_param", str(e.warning))
+        self.assertIn("new_param", str(e.warning))
+
+
+class TestDeprecatedFields(unittest.TestCase):
+    def test_no_change(self):
+
+        @deprecated_attrs({})
+        class Clazz(object):
+            """Some nice class."""
+            class_field = "I'm class_field"
+
+            def __init__(self):
+                self.new_field = "I'm new_field"
+
+            def new_method(self):
+                """Good method."""
+                return "in new_method"
+
+            @staticmethod
+            def new_static_method():
+                return "in new_static_method"
+
+            @classmethod
+            def new_cls_method(cls, param):
+                return "cls methd: {0}".format(param)
+
+        instance = Clazz()
+
+        self.assertEqual(instance.new_field, "I'm new_field")
+        self.assertEqual(instance.class_field, "I'm class_field")
+        self.assertEqual(instance.new_method(), "in new_method")
+        self.assertEqual(instance.new_static_method(), "in new_static_method")
+        self.assertEqual(instance.new_cls_method("a"), "cls methd: a")
+        self.assertEqual(Clazz.new_cls_method("a"), "cls methd: a")
+        self.assertEqual(Clazz.new_static_method(), "in new_static_method")
+        self.assertEqual(instance.__doc__, "Some nice class.")
+        self.assertEqual(instance.new_method.__doc__, "Good method.")
+
+    def test_deprecated_instance_variable(self):
+        @deprecated_attrs({"new_field": "old_field"})
+        class Clazz(object):
+            def __init__(self):
+                self.new_field = "I'm new_field"
+
+        instance = Clazz()
+
+        self.assertEqual(instance.new_field, "I'm new_field")
+
+        with self.assertWarns(DeprecationWarning) as e:
+            self.assertEqual(instance.old_field, "I'm new_field")
+            instance.old_field = "I've been set"
+
+        self.assertEqual(instance.new_field, "I've been set")
+
+        self.assertIn("old_field", str(e.warning))
+
+        with self.assertWarns(DeprecationWarning):
+            del instance.old_field
+
+        self.assertFalse(hasattr(instance, "new_field"))
+
+    def test_deprecated_instance_method(self):
+        @deprecated_attrs({"new_method": "old_method"})
+        class Clazz(object):
+            def new_method(self, param):
+                return "new_method: {0}".format(param)
+
+        instance = Clazz()
+
+        self.assertEqual(instance.new_method("aa"), "new_method: aa")
+        with self.assertWarns(DeprecationWarning) as e:
+            self.assertEqual(instance.old_method("aa"), "new_method: aa")
+
+        self.assertIn("old_method", str(e.warning))
+
+    def test_deprecated_class_method(self):
+        @deprecated_attrs({"foo": "bar"})
+        class Clazz(object):
+            @classmethod
+            def foo(cls, arg):
+                return "foo: {0}".format(arg)
+
+        instance = Clazz()
+
+        self.assertEqual(instance.foo("aa"), "foo: aa")
+        self.assertEqual(Clazz.foo("aa"), "foo: aa")
+
+        with self.assertWarns(DeprecationWarning) as e:
+            self.assertEqual(instance.bar("aa"), "foo: aa")
+        self.assertIn("bar", str(e.warning))
+
+        with self.assertWarns(DeprecationWarning) as e:
+            self.assertEqual(Clazz.bar("aa"), "foo: aa")
+        self.assertIn("bar", str(e.warning))
+
+        self.assertFalse(hasattr(Clazz, "non_existing"))
+
+    def test_deprecated_static_method(self):
+        @deprecated_attrs({"new_stic": "old_stic"})
+        class Clazz(object):
+            @staticmethod
+            def new_stic(param):
+                return "new_stic: {0}".format(param)
+
+        instance = Clazz()
+
+        self.assertEqual(instance.new_stic("aaa"), "new_stic: aaa")
+        self.assertEqual(Clazz.new_stic("aaa"), "new_stic: aaa")
+        with self.assertWarns(DeprecationWarning) as e:
+            self.assertEqual(instance.old_stic("aaa"), "new_stic: aaa")
+        self.assertIn("old_stic", str(e.warning))
+        with self.assertWarns(DeprecationWarning) as e:
+            self.assertEqual(Clazz.old_stic("aaa"), "new_stic: aaa")
+        self.assertIn("old_stic", str(e.warning))
+
+    def test_deprecated_class_variable(self):
+        @deprecated_attrs({"new_cvar": "old_cvar"})
+        class Clazz(object):
+            new_cvar = "some string"
+
+            def method(self):
+                return self.new_cvar
+
+        instance = Clazz()
+
+        self.assertEqual(instance.method(), "some string")
+        Clazz.new_cvar = bytearray(b"new string")
+        self.assertEqual(instance.new_cvar, b"new string")
+
+        with self.assertWarns(DeprecationWarning) as e:
+            self.assertEqual(instance.old_cvar, b"new string")
+        self.assertIn("old_cvar", str(e.warning))
+        self.assertIn("new_cvar", str(e.warning))
+
+        with self.assertWarns(DeprecationWarning) as e:
+            self.assertEqual(Clazz.old_cvar, b"new string")
+        self.assertIn("old_cvar", str(e.warning))
+        self.assertIn("new_cvar", str(e.warning))
+
+        # direct assignment to old value won't work, ex:
+        # Clazz.old_cvar = b'newest string'
+        with self.assertWarns(DeprecationWarning) as e:
+            Clazz.old_cvar[:] = b"newest string"
+        self.assertIn("old_cvar", str(e.warning))
+        self.assertIn("new_cvar", str(e.warning))
+
+        self.assertEqual(instance.method(), b"newest string")
+
+    def test_class_with_custom_getattr(self):
+        @deprecated_attrs({"new_cvar": "old_cvar"})
+        class Clazz(object):
+            new_cvar = "first title"
+
+            def __getattr__(self, name):
+                if name == "intresting":
+                    return "some value"
+                raise AttributeError("Clazz does not have {0}".format(name))
+
+        instance = Clazz()
+
+        self.assertEqual(instance.intresting, "some value")
+        with self.assertWarns(DeprecationWarning) as e:
+            self.assertEqual(instance.old_cvar, "first title")
+
+        self.assertFalse(hasattr(instance, "non_existing"))
+
+    def test_deprecated_attrs_variable_deletion(self):
+        @deprecated_attrs({"new_cvar": "old_cvar"})
+        class Clazz(object):
+            new_cvar = "first title"
+
+            def __init__(self):
+                self.val = "something"
+
+            @classmethod
+            def method(cls):
+                return cls.new_cvar
+
+        instance = Clazz()
+
+        self.assertEqual(instance.method(), "first title")
+        self.assertEqual(instance.new_cvar, "first title")
+
+        with self.assertWarns(DeprecationWarning) as e:
+            self.assertEqual(Clazz.old_cvar, "first title")
+        self.assertIn("old_cvar", str(e.warning))
+        self.assertIn("new_cvar", str(e.warning))
+
+        with self.assertWarns(DeprecationWarning) as e:
+            self.assertEqual(instance.old_cvar, "first title")
+        self.assertIn("old_cvar", str(e.warning))
+        self.assertIn("new_cvar", str(e.warning))
+
+        Clazz.new_cvar = "second"
+
+        self.assertEqual(instance.method(), "second")
+        with self.assertWarns(DeprecationWarning) as e:
+            self.assertEqual(instance.old_cvar, "second")
+        self.assertIn("old_cvar", str(e.warning))
+        self.assertIn("new_cvar", str(e.warning))
+
+        with self.assertWarns(DeprecationWarning) as e:
+            Clazz.old_cvar = "third"
+        self.assertIn("old_cvar", str(e.warning))
+        self.assertIn("new_cvar", str(e.warning))
+
+        self.assertEqual(instance.method(), "third")
+        self.assertEqual(Clazz.new_cvar, "third")
+        self.assertEqual(instance.new_cvar, "third")
+
+        with self.assertWarns(DeprecationWarning) as e:
+            del Clazz.old_cvar
+        self.assertIn("old_cvar", str(e.warning))
+        self.assertIn("new_cvar", str(e.warning))
+
+        self.assertFalse(hasattr(Clazz, "new_cvar"))
+        with self.assertWarns(DeprecationWarning) as e:
+            self.assertFalse(hasattr(Clazz, "old_cvar"))
+
+    def test_class_variable_deletion(self):
+        @deprecated_attrs({"new_cvar": "old_cvar"})
+        class Clazz(object):
+            new_cvar = "first title"
+
+            @classmethod
+            def method(cls):
+                return cls.new_cvar
+
+        instance = Clazz()
+
+        self.assertEqual(instance.method(), "first title")
+        self.assertEqual(instance.new_cvar, "first title")
+
+        with self.assertWarns(DeprecationWarning) as e:
+            self.assertEqual(Clazz.old_cvar, "first title")
+        self.assertIn("old_cvar", str(e.warning))
+        self.assertIn("new_cvar", str(e.warning))
+
+        with self.assertWarns(DeprecationWarning) as e:
+            self.assertEqual(instance.old_cvar, "first title")
+        self.assertIn("old_cvar", str(e.warning))
+        self.assertIn("new_cvar", str(e.warning))
+
+        Clazz.new_cvar = "second"
+
+        self.assertEqual(instance.method(), "second")
+        with self.assertWarns(DeprecationWarning) as e:
+            self.assertEqual(instance.old_cvar, "second")
+        self.assertIn("old_cvar", str(e.warning))
+        self.assertIn("new_cvar", str(e.warning))
+
+        with self.assertWarns(DeprecationWarning) as e:
+            Clazz.old_cvar = "third"
+        self.assertIn("old_cvar", str(e.warning))
+        self.assertIn("new_cvar", str(e.warning))
+
+        self.assertEqual(instance.method(), "third")
+        self.assertEqual(Clazz.new_cvar, "third")
+        self.assertEqual(instance.new_cvar, "third")
+
+        with self.assertWarns(DeprecationWarning) as e:
+            del Clazz.old_cvar
+        self.assertIn("old_cvar", str(e.warning))
+        self.assertIn("new_cvar", str(e.warning))
+
+        self.assertFalse(hasattr(Clazz, "new_cvar"))
+        with self.assertWarns(DeprecationWarning) as e:
+            self.assertFalse(hasattr(Clazz, "old_cvar"))

--- a/unit_tests/test_tlslite_utils_deprecations.py
+++ b/unit_tests/test_tlslite_utils_deprecations.py
@@ -1,0 +1,71 @@
+# Copyright (c) 2018, Hubert Kario
+#
+# See the LICENSE file for legal information regarding use of this file.
+
+# compatibility with Python 2.6, for that we need unittest2 package,
+# which is not available on 3.3 or 3.4
+try:
+    import unittest2 as unittest
+except ImportError:
+    import unittest
+
+try:
+    import mock
+    from mock import call
+except ImportError:
+    import unittest.mock as mock
+    from unittest.mock import call
+
+from tlslite.utils.deprecations import deprecated_params
+
+
+class TestDeprecatedParams(unittest.TestCase):
+    def test_no_changes(self):
+        @deprecated_params({})
+        def method(param_a, param_b):
+            """Some doc string."""
+            return (param_a, param_b)
+
+        a = mock.Mock()
+        b = mock.Mock()
+
+        r = method(param_a=a, param_b=b)
+
+        self.assertIsInstance(r, tuple)
+        self.assertEqual(r, (a, b))
+        self.assertIs(r[0], a)
+        self.assertIs(r[1], b)
+
+        self.assertEqual("Some doc string.", method.__doc__)
+
+    def test_change_param(self):
+        @deprecated_params({'param_a': 'old_param'})
+        def method(param_a, param_b):
+            return (param_a, param_b)
+
+        old = mock.Mock()
+        b = mock.Mock()
+
+        with self.assertWarns(DeprecationWarning) as e:
+            r = method(old_param=old, param_b=b)
+
+        self.assertIsInstance(r, tuple)
+        self.assertEqual(r, (old, b))
+        self.assertIs(r[0], old)
+        self.assertIs(r[1], b)
+
+        self.assertIn('old_param', str(e.warning))
+
+    def test_both_params(self):
+        @deprecated_params({'param_a': 'older_param'})
+        def method(param_a, param_b):
+            return (param_a, param_b)
+
+        a = mock.Mock()
+        b = mock.Mock()
+        c = mock.Mock()
+
+        with self.assertRaises(TypeError) as e:
+            method(param_a=a, param_b=b, older_param=c)
+
+        self.assertIn('multiple values', str(e.exception))


### PR DESCRIPTION
old code used camelCase for attributes and method names, that's unpythonic

add decorators that allow us to retain API while changing names of those identifiers

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/tomato42/tlslite-ng/218)
<!-- Reviewable:end -->
