### PR TITLE
Fixes for python 3.7 support

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -23,6 +23,7 @@ python:
   - 3.4
   - 3.5
   - 3.6
+  - 3.7-dev
 
 env:
   - TACKPY=true
@@ -52,6 +53,8 @@ matrix:
       env: PYCRYPTO=true
     - python: 3.6
       env: PYCRYPTO=true
+    - python: 3.7-dev
+      env: PYCRYPTO=true
     - python: 2.7
       env: GMPY=true
     - python: 3.4
@@ -67,6 +70,8 @@ matrix:
     - python: 3.5
       env: M2CRYPTO=true PYCRYPTO=true GMPY=true
     - python: 3.6
+      env: M2CRYPTO=true PYCRYPTO=true GMPY=true
+    - python: 3.7-dev
       env: M2CRYPTO=true PYCRYPTO=true GMPY=true
 
 before_install:

--- a/setup.py
+++ b/setup.py
@@ -37,6 +37,7 @@ setup(name="tlslite-ng",
             'Programming Language :: Python :: 3.4',
             'Programming Language :: Python :: 3.5',
             'Programming Language :: Python :: 3.6',
+            'Programming Language :: Python :: 3.7',
             'Topic :: Security :: Cryptography',
             'Topic :: Software Development :: Libraries :: Python Modules',
             'Topic :: System :: Networking'

--- a/tlslite/integration/asyncstatemachine.py
+++ b/tlslite/integration/asyncstatemachine.py
@@ -197,7 +197,7 @@ class AsyncStateMachine:
         :param generator handshaker: A generator created by using one of the
             asynchronous handshake functions (i.e.
             :py:meth:`~.TLSConnection.handshakeServerAsync` , or
-            handshakeClientxxx(..., async=True).
+            handshakeClientxxx(..., async_=True).
         """
         try:
             self._checkAssert(0)

--- a/tlslite/tlsconnection.py
+++ b/tlslite/tlsconnection.py
@@ -31,6 +31,7 @@ from .mathtls import *
 from .handshakesettings import HandshakeSettings
 from .handshakehashes import HandshakeHashes
 from .utils.tackwrapper import *
+from .utils.deprecations import deprecated_params
 from .keyexchange import KeyExchange, RSAKeyExchange, DHE_RSAKeyExchange, \
         ECDHE_RSAKeyExchange, SRPKeyExchange, ADHKeyExchange, \
         AECDHKeyExchange, FFDHKeyExchange, ECDHKeyExchange
@@ -111,9 +112,12 @@ class TLSConnection(TLSRecordLayer):
     # Client Handshake Functions
     #*********************************************************
 
+    @deprecated_params({"async_": "async"},
+                       "'{old_name}' is a keyword in Python 3.7, use"
+                       "'{new_name}'")
     def handshakeClientAnonymous(self, session=None, settings=None,
                                  checker=None, serverName=None,
-                                 async=False):
+                                 async_=False):
         """Perform an anonymous handshake in the role of client.
 
         This function performs an SSL or TLS handshake using an
@@ -147,8 +151,8 @@ class TLSConnection(TLSRecordLayer):
         :type serverName: string
         :param serverName: The ServerNameIndication TLS Extension.
 
-        :type async: bool
-        :param async: If False, this function will block until the
+        :type async_: bool
+        :param async_: If False, this function will block until the
             handshake is completed.  If True, this function will return a
             generator.  Successive invocations of the generator will
             return 0 if it is waiting to read from the socket, 1 if it is
@@ -156,7 +160,7 @@ class TLSConnection(TLSRecordLayer):
             the handshake operation is completed.
 
         :rtype: None or an iterable
-        :returns: If 'async' is True, a generator object will be
+        :returns: If 'async_' is True, a generator object will be
             returned.
 
         :raises socket.error: If a socket error occurs.
@@ -171,15 +175,18 @@ class TLSConnection(TLSRecordLayer):
                                                 settings=settings,
                                                 checker=checker,
                                                 serverName=serverName)
-        if async:
+        if async_:
             return handshaker
         for result in handshaker:
             pass
 
+    @deprecated_params({"async_": "async"},
+                       "'{old_name}' is a keyword in Python 3.7, use"
+                       "'{new_name}'")
     def handshakeClientSRP(self, username, password, session=None,
                            settings=None, checker=None,
                            reqTack=True, serverName=None,
-                           async=False):
+                           async_=False):
         """Perform an SRP handshake in the role of client.
 
         This function performs a TLS/SRP handshake.  SRP mutually
@@ -224,8 +231,8 @@ class TLSConnection(TLSRecordLayer):
         :type serverName: string
         :param serverName: The ServerNameIndication TLS Extension.
 
-        :type async: bool
-        :param async: If False, this function will block until the
+        :type async_: bool
+        :param async_: If False, this function will block until the
             handshake is completed.  If True, this function will return a
             generator.  Successive invocations of the generator will
             return 0 if it is waiting to read from the socket, 1 if it is
@@ -233,7 +240,7 @@ class TLSConnection(TLSRecordLayer):
             the handshake operation is completed.
 
         :rtype: None or an iterable
-        :returns: If 'async' is True, a generator object will be
+        :returns: If 'async_' is True, a generator object will be
             returned.
 
         :raises socket.error: If a socket error occurs.
@@ -256,17 +263,20 @@ class TLSConnection(TLSRecordLayer):
         # fashion, returning 1 when it is waiting to able to write, 0 when
         # it is waiting to read.
         #
-        # If 'async' is True, the generator is returned to the caller, 
+        # If 'async_' is True, the generator is returned to the caller,
         # otherwise it is executed to completion here.  
-        if async:
+        if async_:
             return handshaker
         for result in handshaker:
             pass
 
+    @deprecated_params({"async_": "async"},
+                       "'{old_name}' is a keyword in Python 3.7, use"
+                       "'{new_name}'")
     def handshakeClientCert(self, certChain=None, privateKey=None,
                             session=None, settings=None, checker=None,
                             nextProtos=None, reqTack=True, serverName=None,
-                            async=False, alpn=None):
+                            async_=False, alpn=None):
         """Perform a certificate-based handshake in the role of client.
 
         This function performs an SSL or TLS handshake.  The server
@@ -323,8 +333,8 @@ class TLSConnection(TLSRecordLayer):
         :type serverName: string
         :param serverName: The ServerNameIndication TLS Extension.
 
-        :type async: bool
-        :param async: If False, this function will block until the
+        :type async_: bool
+        :param async_: If False, this function will block until the
             handshake is completed.  If True, this function will return a
             generator.  Successive invocations of the generator will
             return 0 if it is waiting to read from the socket, 1 if it is
@@ -337,7 +347,7 @@ class TLSConnection(TLSRecordLayer):
             Example items in the array include b'http/1.1' or b'h2'.
 
         :rtype: None or an iterable
-        :returns: If 'async' is True, a generator object will be
+        :returns: If 'async_' is True, a generator object will be
             returned.
 
         :raises socket.error: If a socket error occurs.
@@ -360,9 +370,9 @@ class TLSConnection(TLSRecordLayer):
         # fashion, returning 1 when it is waiting to able to write, 0 when
         # it is waiting to read.
         #
-        # If 'async' is True, the generator is returned to the caller, 
-        # otherwise it is executed to completion here.                        
-        if async:
+        # If 'async_' is True, the generator is returned to the caller,
+        # otherwise it is executed to completion here.
+        if async_:
             return handshaker
         for result in handshaker:
             pass


### PR DESCRIPTION
In python 3.7, async and await are new reserved keywords which cannot
be used as variable names or arguments. This commit renames some
parameters called async to comply with that. It also updates metadata
identifiers to state python 3.7 support as well as runs with mentioned
version on travis.

(fixed'up #216, fixes #214 )

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/tomato42/tlslite-ng/221)
<!-- Reviewable:end -->
