### PR TITLE
Fix python2 compatibility issue with X509 DER parsing

### DIFF
--- a/tlslite/x509.py
+++ b/tlslite/x509.py
@@ -58,7 +58,7 @@ class X509(object):
         :param bytes: A DER-encoded X.509 certificate.
         """
         self.bytes = bytearray(bytes)
-        p = ASN1Parser(bytes)
+        p = ASN1Parser(self.bytes)
 
         #Get the tbsCertificate
         tbsCertificateP = p.getChild(0)


### PR DESCRIPTION
The documentation for X509.parseBinary claims to support python2 str as an input.
The input string is correctly converted to bytearray, but the array is not
passed to the ASN1Parser - the parser gets the original string and
fails with Type error when attempting to logical-or the characters with an integer.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/tomato42/tlslite-ng/223)
<!-- Reviewable:end -->
