### PR TITLE
fix M2Crypto 0.27.0 test compatibility

### DIFF
--- a/unit_tests/test_tlslite_utils_keyfactory.py
+++ b/unit_tests/test_tlslite_utils_keyfactory.py
@@ -173,7 +173,7 @@ class TestParsePEMKey(unittest.TestCase):
 
         # XXX doesn't handle files without newlines
         # old version of M2Crypto return a Null, in Python3 it raises exception
-        if M2Crypto.version_info >= (0, 27, 0):
+        if M2Crypto.version_info >= (0, 28, 0):
             exp = M2Crypto.EVP.EVPError
         else:
             exp = SyntaxError


### PR DESCRIPTION
the different behaviour was introduced in 0.28.0, not
in 0.27.0, so the test needs to check against 0.28.0

also (0, 27, 0) > (0, 27) evaluates to True
(this is where the original confuson came from)

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/tomato42/tlslite-ng/232)
<!-- Reviewable:end -->
