### PR TITLE
verify the mac even if the padding is 1 byte long

### DIFF
--- a/tlslite/utils/constanttime.py
+++ b/tlslite/utils/constanttime.py
@@ -170,7 +170,7 @@ def ct_check_cbc_mac_and_pad(data, mac, seqnumBytes, contentType, version):
     data_mac.update(compatHMAC(data[:start_pos]))
 
     # don't check past the array end (already checked to be >= zero)
-    end_pos = data_len - 1 - mac.digest_size
+    end_pos = data_len - mac.digest_size
 
     # calculate all possible
     for i in range(start_pos, end_pos): # constant for given overall length


### PR DESCRIPTION
off-by-one error on mac checking, if the padding is of
minimal length (a single 0x00 byte), the mac is not
checked and thus the return value is never falsified

this fixes the issue

backport of 3674815d1b0f7484454995e2737a352e0a6a93d8

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/tomato42/tlslite-ng/235)
<!-- Reviewable:end -->
