### PR TITLE
try to ensure that the alert was delivered to client

### DIFF
--- a/unit_tests/test_tlslite_recordlayer.py
+++ b/unit_tests/test_tlslite_recordlayer.py
@@ -315,10 +315,8 @@ class TestRecordSocket(unittest.TestCase):
 
         sock = RecordSocket(mockSock)
 
-        for result in sock.recv():
-            break
-
-        self.assertEqual(0, result)
+        with self.assertRaises(TLSAbruptCloseError):
+            next(sock.recv())
 
     def test_recv_with_SSL2_record_with_incomplete_header(self):
         mockSock = MockSocket(bytearray(
@@ -327,10 +325,8 @@ class TestRecordSocket(unittest.TestCase):
 
         sock = RecordSocket(mockSock)
 
-        for result in sock.recv():
-            break
-
-        self.assertEqual(0, result)
+        with self.assertRaises(TLSAbruptCloseError):
+            next(sock.recv())
 
     def test_recv_with_long_SSL2_header(self):
         mockSock = MockSocket(bytearray(

--- a/unit_tests/test_tlslite_tlsrecordlayer.py
+++ b/unit_tests/test_tlslite_tlsrecordlayer.py
@@ -210,10 +210,8 @@ class TestTLSRecordLayer(unittest.TestCase):
         sock = TLSRecordLayer(mockSock)
 
         # XXX using private method!
-        for result in sock._getNextRecord():
-            break
-
-        self.assertEqual(0, result)
+        with self.assertRaises(TLSAbruptCloseError):
+            next(sock._getNextRecord())
 
     def test__getNextRecord_with_SSL2_record_with_incomplete_header(self):
         mockSock = MockSocket(bytearray(
@@ -223,10 +221,8 @@ class TestTLSRecordLayer(unittest.TestCase):
         sock = TLSRecordLayer(mockSock)
 
         # XXX using private method
-        for result in sock._getNextRecord():
-            break
-
-        self.assertEqual(0, result)
+        with self.assertRaises(TLSAbruptCloseError):
+            next(sock._getNextRecord())
 
     def test__getNextRecord_with_empty_handshake(self):
 


### PR DESCRIPTION
after receiving alert, drop all client messages on the
floor, wait for it to close socket or send multiple
messages (as that likely means it was sufficient
delay to send the messages from the kernel/NIC queue)

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/tomato42/tlslite-ng/236)
<!-- Reviewable:end -->
