### PR TITLE
increase timeout for SRP (db) case

### DIFF
--- a/tests/tlstest.py
+++ b/tests/tlstest.py
@@ -92,7 +92,7 @@ def clientTestCmd(argv):
 
     #open synchronisation FIFO
     synchro = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
-    synchro.settimeout(15)
+    synchro.settimeout(60)
     synchro.connect((address[0], address[1]-1))
 
     def connect():
@@ -253,7 +253,11 @@ def clientTestCmd(argv):
 
     print("Test {0} - good SRP (db)".format(test_no))
     print("client {0} - waiting for synchro".format(time.time()))
-    synchro.recv(1)
+    try:
+        synchro.recv(1)
+    except Exception:
+        print("client {0} - wait abort".format(time.time()))
+        raise
     print("client {0} - synchro received".format(time.time()))
     connection = connect()
     settings = HandshakeSettings()


### PR DESCRIPTION
because of issues like the ones in #219 the test runs
sometimes fail (with logging indicating very slow disk
access on slow machine), try increasing the timeout to
combat this

also add logging to show how long the client really waited
before aborting

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/tomato42/tlslite-ng/238)
<!-- Reviewable:end -->
