### PR TITLE
fix API break in certChain property

### DIFF
--- a/tlslite/messages.py
+++ b/tlslite/messages.py
@@ -1104,16 +1104,17 @@ class Certificate(HandshakeMsg):
 
     @property
     def cert_chain(self):
+        """Getter for the cert_chain property."""
         if self._cert_chain:
             return self._cert_chain
         elif self.certificate_list is None:
             return None
-        else:
-            return X509CertChain([i.certificate
-                                  for i in self.certificate_list])
+        return X509CertChain([i.certificate
+                              for i in self.certificate_list])
 
     @cert_chain.setter
     def cert_chain(self, cert_chain):
+        """Setter for the cert_chain property."""
         if isinstance(cert_chain, X509CertChain):
             self._cert_chain = cert_chain
             self.certificate_list = [CertificateEntry(self.certificateType)
@@ -1124,6 +1125,7 @@ class Certificate(HandshakeMsg):
 
     @deprecated_params({"cert_chain": "certChain"})
     def create(self, cert_chain, context=None):
+        """Initialise fields of the class."""
         self.cert_chain = cert_chain
         self.certificate_request_context = context
         return self
@@ -1206,13 +1208,12 @@ class Certificate(HandshakeMsg):
 
     def __repr__(self):
         if self.version <= (3, 3):
-            return "Certificate(cert_chain={0!r})".format(
-                    self.cert_chain.x509List)
-        else:
-            return "Certificate(request_context={0!r}, "\
-                   "certificate_list={1!r})"\
-                    .format(self.certificate_request_context,
-                            self.certificate_list)
+            return "Certificate(cert_chain={0!r})"\
+                   .format(self.cert_chain.x509List)
+        return "Certificate(request_context={0!r}, "\
+               "certificate_list={1!r})"\
+               .format(self.certificate_request_context,
+                       self.certificate_list)
 
 
 class CertificateRequest(HandshakeMsg):

--- a/tlslite/messages.py
+++ b/tlslite/messages.py
@@ -1112,8 +1112,8 @@ class Certificate(HandshakeMsg):
             return X509CertChain([i.certificate
                                   for i in self.certificate_list])
 
-    @deprecated_params({"cert_chain": "certChain"})
-    def create(self, cert_chain, context=None):
+    @cert_chain.setter
+    def cert_chain(self, cert_chain):
         if isinstance(cert_chain, X509CertChain):
             self._cert_chain = cert_chain
             self.certificate_list = [CertificateEntry(self.certificateType)
@@ -1121,6 +1121,10 @@ class Certificate(HandshakeMsg):
                                      in cert_chain.x509List]
         else:
             self.certificate_list = cert_chain
+
+    @deprecated_params({"cert_chain": "certChain"})
+    def create(self, cert_chain, context=None):
+        self.cert_chain = cert_chain
         self.certificate_request_context = context
         return self
 

--- a/tlslite/messages.py
+++ b/tlslite/messages.py
@@ -18,6 +18,7 @@ from .constants import *
 from .x509 import X509
 from .x509certchain import X509CertChain
 from .utils.tackwrapper import *
+from .utils.deprecations import deprecated_attrs, deprecated_params
 from .extensions import *
 
 
@@ -1091,33 +1092,35 @@ class CertificateEntry(object):
                 self.certificate, self.extensions)
 
 
+@deprecated_attrs({"cert_chain": "certChain"})
 class Certificate(HandshakeMsg):
     def __init__(self, certificateType, version=(3, 2)):
         HandshakeMsg.__init__(self, HandshakeType.certificate)
         self.certificateType = certificateType
-        self._certChain = None
+        self._cert_chain = None
         self.version = version
         self.certificate_list = None
         self.certificate_request_context = None
 
     @property
-    def certChain(self):
-        if self._certChain:
-            return self._certChain
+    def cert_chain(self):
+        if self._cert_chain:
+            return self._cert_chain
         elif self.certificate_list is None:
             return None
         else:
             return X509CertChain([i.certificate
                                   for i in self.certificate_list])
 
-    def create(self, certChain, context=None):
-        if isinstance(certChain, X509CertChain):
-            self._certChain = certChain
+    @deprecated_params({"cert_chain": "certChain"})
+    def create(self, cert_chain, context=None):
+        if isinstance(cert_chain, X509CertChain):
+            self._cert_chain = cert_chain
             self.certificate_list = [CertificateEntry(self.certificateType)
                                      .create(i, []) for i
-                                     in certChain.x509List]
+                                     in cert_chain.x509List]
         else:
-            self.certificate_list = certChain
+            self.certificate_list = cert_chain
         self.certificate_request_context = context
         return self
 
@@ -1147,7 +1150,7 @@ class Certificate(HandshakeMsg):
                 certificate_list.append(x509)
                 index += len(certBytes)+3
             if certificate_list:
-                self._certChain = X509CertChain(certificate_list)
+                self._cert_chain = X509CertChain(certificate_list)
         else:
             raise AssertionError()
 
@@ -1173,8 +1176,8 @@ class Certificate(HandshakeMsg):
         w = Writer()
         if self.certificateType == CertificateType.x509:
             chainLength = 0
-            if self._certChain:
-                certificate_list = self._certChain.x509List
+            if self._cert_chain:
+                certificate_list = self._cert_chain.x509List
             else:
                 certificate_list = []
             # determine length
@@ -1199,8 +1202,8 @@ class Certificate(HandshakeMsg):
 
     def __repr__(self):
         if self.version <= (3, 3):
-            return "Certificate(certChain={0!r})".format(
-                    self.certChain.x509List)
+            return "Certificate(cert_chain={0!r})".format(
+                    self.cert_chain.x509List)
         else:
             return "Certificate(request_context={0!r}, "\
                    "certificate_list={1!r})"\

--- a/unit_tests/test_tlslite_messages.py
+++ b/unit_tests/test_tlslite_messages.py
@@ -2926,7 +2926,7 @@ class TestCertificate(unittest.TestCase):
         cert = cert.create(X509CertChain([bytearray(b'one'),
                                           bytearray(b'two')]))
         self.assertEqual(repr(cert),
-                "Certificate(certChain=[bytearray(b'one'), "
+                "Certificate(cert_chain=[bytearray(b'one'), "
                 "bytearray(b'two')])")
 
     def test___repr___tls_1_3(self):


### PR DESCRIPTION
`certChain` was a regular variable so we need to retain a setter for it (lack of it breaks `cipherscan`)

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/tomato42/tlslite-ng/239)
<!-- Reviewable:end -->
