### PR TITLE
Move server key exchange sig

### DIFF
--- a/tlslite/tlsconnection.py
+++ b/tlslite/tlsconnection.py
@@ -2941,7 +2941,9 @@ class TLSConnection(TLSRecordLayer):
         # If resumption was not requested, or
         # we have no session cache, or
         # the client's session_id was not found in cache:
+#pylint: disable = undefined-loop-variable
         yield (clientHello, cipherSuite, version, scheme)
+#pylint: enable = undefined-loop-variable
 
     def _serverSRPKeyExchange(self, clientHello, serverHello, verifierDB,
                               cipherSuite, privateKey, serverCertChain,

--- a/tlslite/tlsconnection.py
+++ b/tlslite/tlsconnection.py
@@ -2121,6 +2121,12 @@ class TLSConnection(TLSRecordLayer):
             sh_extensions.append(SrvPreSharedKeyExtension()
                                  .create(selected_psk))
 
+        if selected_psk is None:
+            scheme = self._pickServerKeyExchangeSig(settings,
+                                                    clientHello,
+                                                    serverCertChain,
+                                                    self.version)
+
         serverHello = ServerHello()
         # in TLS1.3 the version selected is sent in extension, (3, 3) is
         # just dummy value to workaround broken middleboxes
@@ -2188,10 +2194,6 @@ class TLSConnection(TLSRecordLayer):
 
             certificate_verify = CertificateVerify(self.version)
 
-            scheme = self._pickServerKeyExchangeSig(settings,
-                                                    clientHello,
-                                                    serverCertChain,
-                                                    self.version)
             signature_scheme = getattr(SignatureScheme, scheme)
             keyType = SignatureScheme.getKeyType(scheme)
             padType = SignatureScheme.getPadding(scheme)


### PR DESCRIPTION
Now the connection is closed at the beginning if there is no common signature algorithms.
This fix is due to new test-scirpt (https://github.com/tomato42/tlsfuzzer/issues/209).

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/tomato42/tlslite-ng/244)
<!-- Reviewable:end -->
