### PR TITLE
fix server key exchange sig for TLS1.3, TLS1.2

### DIFF
--- a/tlslite/tlsconnection.py
+++ b/tlslite/tlsconnection.py
@@ -2525,10 +2525,16 @@ class TLSConnection(TLSRecordLayer):
 
         scheme = None
         if version >= (3, 4):
-            scheme = self._pickServerKeyExchangeSig(settings,
-                                                    clientHello,
-                                                    certChain,
-                                                    version)
+            try:
+                scheme = self._pickServerKeyExchangeSig(settings,
+                                                        clientHello,
+                                                        certChain,
+                                                        version)
+            except TLSHandshakeFailure as alert:
+                for result in self._sendError(
+                        AlertDescription.handshake_failure,
+                        str(alert)):
+                    yield result
 
         #Check if there's intersection between supported curves by client and
         #server

--- a/tlslite/tlsconnection.py
+++ b/tlslite/tlsconnection.py
@@ -2523,10 +2523,12 @@ class TLSConnection(TLSRecordLayer):
         # TODO when TLS 1.3 is final, check the client hello random for
         # downgrade too
 
-        scheme = self._pickServerKeyExchangeSig(settings,
-                                                clientHello,
-                                                certChain,
-                                                version)
+        scheme = None
+        if version >= (3, 4):
+            scheme = self._pickServerKeyExchangeSig(settings,
+                                                    clientHello,
+                                                    certChain,
+                                                    version)
 
         #Check if there's intersection between supported curves by client and
         #server


### PR DESCRIPTION
The merge https://github.com/tomato42/tlslite-ng/pull/244 introduced regressions to tlsfuzzer.
To fix this, we need to abort the connection earlier in TLS1.3 and later in TLS1.2.
So a condition was added to fix this issue.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/tomato42/tlslite-ng/247)
<!-- Reviewable:end -->
