### PR TITLE
TLS 1.3 version negotiation fixes

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -95,7 +95,7 @@ before_install:
   - git fetch origin master:refs/remotes/origin/master
 
 install:
-  - if [[ $TRAVIS_PYTHON_VERSION == '2.6' ]]; then travis_retry pip install unittest2 'isort<4.3'; fi
+  - if [[ $TRAVIS_PYTHON_VERSION == '2.6' ]]; then travis_retry pip install unittest2 'isort<4.3' 'inflect<0.3.1'; fi
   - if [[ $TRAVIS_PYTHON_VERSION == '2.7' ]]; then travis_retry pip install unittest2; fi
   - if [[ $TACKPY == 'true' ]]; then travis_retry pip install tackpy; fi
   - if [[ $M2CRYPTO == 'true' ]]; then travis_retry pip install --pre m2crypto; fi

--- a/tlslite/tlsconnection.py
+++ b/tlslite/tlsconnection.py
@@ -2507,7 +2507,7 @@ class TLSConnection(TLSRecordLayer):
             # it as well as that also switches it to a mode where the
             # content type is encrypted
             # use the backwards compatible TLS 1.2 version instead
-            self.version = (3, 3)
+            self.version = min((3, 3), high_ver)
             version = high_ver
         elif clientHello.client_version > settings.maxVersion:
             # in TLS 1.3 the version is negotiatied with extension,

--- a/tlslite/tlsconnection.py
+++ b/tlslite/tlsconnection.py
@@ -2496,6 +2496,12 @@ class TLSConnection(TLSRecordLayer):
         if versionsExt:
             high_ver = getFirstMatching(settings.versions,
                                         versionsExt.versions)
+            if not high_ver:
+                for result in self._sendError(
+                        AlertDescription.protocol_version,
+                        "supported_versions did not include version we "
+                        "support"):
+                    yield result
         if high_ver:
             # when we selected TLS 1.3, we cannot set the record layer to
             # it as well as that also switches it to a mode where the


### PR DESCRIPTION
fixes #254 

* `supported_versions` can be used to negotiate pre TLS 1.2 version
* `supported_version` must list a recognised version for the negotiation to be successful

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/tomato42/tlslite-ng/257)
<!-- Reviewable:end -->
