### PR TITLE
fix alert for zero-length records

### DIFF
--- a/tlslite/tlsrecordlayer.py
+++ b/tlslite/tlsrecordlayer.py
@@ -926,13 +926,13 @@ class TLSRecordLayer(object):
 
         header, parser = result
 
-        # RFC5246 section 5.2.1: Implementations MUST NOT send
+        # RFC5246 section 6.2.1: Implementations MUST NOT send
         # zero-length fragments of content types other than Application
         # Data.
         if header.type != ContentType.application_data \
                 and parser.getRemainingLength() == 0:
-            for result in self._sendError(\
-                    AlertDescription.decode_error, \
+            for result in self._sendError(
+                    AlertDescription.unexpected_message,
                     "Received empty non-application data record"):
                 yield result
 


### PR DESCRIPTION
TLS 1.3 states that to zero-length records the
implementation needs to reply with "unexpected_message"
alert

also fix typo in reference

fixes #255

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/tomato42/tlslite-ng/259)
<!-- Reviewable:end -->
