### PR TITLE
honour the expected type when receiving messages

### DIFF
--- a/tlslite/tlsrecordlayer.py
+++ b/tlslite/tlsrecordlayer.py
@@ -685,11 +685,6 @@ class TLSRecordLayer(object):
                         break
                 recordHeader, p = result
 
-                #If this is an empty application-data fragment, try again
-                if recordHeader.type == ContentType.application_data:
-                    if p.index == len(p.bytes):
-                        continue
-
                 # if this is a CCS message in TLS 1.3, sanity check and
                 # continue
                 if self.version > (3, 3) and \
@@ -770,6 +765,11 @@ class TLSRecordLayer(object):
                             AlertDescription.unexpected_message,
                             "received type=%d" % recordHeader.type):
                         yield result
+
+                #If this is an empty application-data fragment, try again
+                if recordHeader.type == ContentType.application_data:
+                    if p.index == len(p.bytes):
+                        continue
 
                 break
 


### PR DESCRIPTION
because the check for empty application data was before
the check for acceptable types, the empty application
data messages were accepted in the middle of handshake, this
fixes that

fixes #256

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/tomato42/tlslite-ng/260)
<!-- Reviewable:end -->
