### PR TITLE
fix python36 application data expectation

### DIFF
--- a/scripts/tls.py
+++ b/scripts/tls.py
@@ -456,6 +456,10 @@ def serverCmd(argv):
         settings.pskConfigs = [(psk_ident, psk, psk_hash)]
     settings.ticketKeys = [getRandomBytes(32)]
 
+    class MySimpleHTTPHandler(SimpleHTTPRequestHandler):
+        """Buffer the header and body of HTTP message."""
+        wbufsize = -1
+
     class MyHTTPServer(ThreadingMixIn, TLSSocketServerMixIn, HTTPServer):
         def handshake(self, connection):
             print("About to handshake...")
@@ -514,7 +518,7 @@ def serverCmd(argv):
             printExporter(connection, expLabel, expLength)
             return True
 
-    httpd = MyHTTPServer(address, SimpleHTTPRequestHandler)
+    httpd = MyHTTPServer(address, MySimpleHTTPHandler)
     httpd.serve_forever()
 
 


### PR DESCRIPTION
Now the header and body of HTTP response is buffered and sent as one message for python3.6

fixes #241

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/tomato42/tlslite-ng/261)
<!-- Reviewable:end -->
