### PR TITLE
add handshake types from draft TLS 1.3 versions

### DIFF
--- a/tlslite/constants.py
+++ b/tlslite/constants.py
@@ -103,6 +103,7 @@ class HandshakeType(TLSEnum):
     client_hello = 1
     server_hello = 2
     new_session_ticket = 4
+    hello_retry_request = 6  # draft version of TLS 1.3
     encrypted_extensions = 8
     certificate = 11
     server_key_exchange = 12


### PR DESCRIPTION
since those IDs are useful for scanners and fuzzers,
keep them in single place, in tlslite-ng

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/tomato42/tlslite-ng/264)
<!-- Reviewable:end -->
