### PR TITLE
switch to python-coveralls for py2.6 and py3.2 support

### DIFF
--- a/build-requirements.txt
+++ b/build-requirements.txt
@@ -1,3 +1,3 @@
 pylint
 diff_cover
-coveralls
+python-coveralls


### PR DESCRIPTION
the official package keeps dropping older versions of
python, use the older one