### PR TITLE
Coverage fixes

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -97,13 +97,13 @@ before_install:
   - chmod +x ./cc-test-reporter
 
 install:
-  - if [[ $TRAVIS_PYTHON_VERSION == '2.6' ]]; then travis_retry pip install unittest2 'isort<4.3' 'inflect<0.3.1'; fi
+  - if [[ $TRAVIS_PYTHON_VERSION == '2.6' ]]; then travis_retry pip install unittest2 'isort<4.3' 'inflect<0.3.1' 'coveralls<1.3.0' 'pyopenssl<18'; fi
   - if [[ $TRAVIS_PYTHON_VERSION == '2.7' ]]; then travis_retry pip install unittest2; fi
   - if [[ $TACKPY == 'true' ]]; then travis_retry pip install tackpy; fi
   - if [[ $M2CRYPTO == 'true' ]]; then travis_retry pip install --pre m2crypto; fi
   - if [[ $PYCRYPTO == 'true' ]]; then travis_retry pip install pycrypto; fi
   - if [[ $GMPY == 'true' ]]; then travis_retry pip install gmpy; fi
-  - if [[ $TRAVIS_PYTHON_VERSION == '3.2' ]]; then travis_retry pip install 'coverage<4' 'hypothesis<1.10'; elif [[ $TRAVIS_PYTHON_VERSION == '3.3' ]]; then travis_retry pip install 'coverage' 'hypothesis<3.44' ; elif [[ $TRAVIS_PYTHON_VERSION == '2.6' ]]; then travis_retry pip install coverage 'hypothesis<3'; else travis_retry pip install coverage hypothesis; fi
+  - if [[ $TRAVIS_PYTHON_VERSION == '3.2' ]]; then travis_retry pip install 'coverage<4' 'hypothesis<1.10' 'coveralls<1' 'urllib3<1.11' 'requests<2.11'; elif [[ $TRAVIS_PYTHON_VERSION == '3.3' ]]; then travis_retry pip install 'coverage' 'hypothesis<3.44' 'coveralls'; elif [[ $TRAVIS_PYTHON_VERSION == '2.6' ]]; then travis_retry pip install coverage 'hypothesis<3'; else travis_retry pip install coverage hypothesis coveralls; fi
   - travis_retry pip install -r requirements.txt
   - travis_retry pip install -r build-requirements.txt
   - if [[ $CC_COV == 'true' ]]; then ./cc-test-reporter before-build; fi

--- a/.travis.yml
+++ b/.travis.yml
@@ -115,8 +115,12 @@ script:
       else
           coverage run --branch --source tlslite -m unittest discover;
       fi
+  - make test-local
+  # --appends is supported only in the new coverage (>4)
+  - if [[ $TRAVIS_PYTHON_VERSION != '3.2' ]]; then coverage combine --append; fi
   - coverage report -m
-  - ./setup.py install && make test
+  - ./setup.py install
+  - make test
   # pylint doesn't work on 2.6: https://bitbucket.org/logilab/pylint/issue/390/py26-compatiblity-broken
   # diff-quality doesn't work on 3.2: https://github.com/edx/diff-cover/issues/94
   - |

--- a/Makefile
+++ b/Makefile
@@ -39,45 +39,56 @@ dist: docs
 	./setup.py sdist
 
 test:
-	cd tests/ && python ./tlstest.py server localhost:4433 . & sleep 4
-	cd tests/ && python ./tlstest.py client localhost:4433 .
+	python tests/tlstest.py server localhost:4433 tests & sleep 4
+	python tests/tlstest.py client localhost:4433 tests
 
 test-local:
-	cd tests/ && PYTHONPATH=.. python ./tlstest.py server localhost:4433 . & sleep 4
-	cd tests/ && PYTHONPATH=.. python ./tlstest.py client localhost:4433 .
+	PYTHONPATH=. COVERAGE_FILE=.coverage.server coverage run --branch --source tlslite tests/tlstest.py server localhost:4433 tests & sleep 4
+	PYTHONPATH=. COVERAGE_FILE=.coverage.client coverage run --branch --source tlslite tests/tlstest.py client localhost:4433 tests
 
 test-dev:
 ifdef PYTHON2
 	@echo "Running test suite with Python 2"
+ifndef COVERAGE2
 	python2 -m unittest discover -v
-	cd tests/ && PYTHONPATH=.. python2 ./tlstest.py server localhost:4433 . & sleep 4
-	cd tests/ && PYTHONPATH=.. python2 ./tlstest.py client localhost:4433 .
+else
+	coverage2 run --branch --source tlslite -m unittest discover
+endif
+	PYTHONPATH=. COVERAGE_FILE=.coverage.2.server coverage2 run --branch --source tlslite tests/tlstest.py server localhost:4433 tests & sleep 4
+	PYTHONPATH=. COVERAGE_FILE=.coverage.2.client coverage2 run --branch --source tlslite tests/tlstest.py client localhost:4433 tests
 endif
 ifdef PYTHON3
 	@echo "Running test suite with Python 3"
+ifndef COVERAGE2
 	python3 -m unittest discover -v
-	cd tests/ && PYTHONPATH=.. python3 ./tlstest.py server localhost:4433 . & sleep 4
-	cd tests/ && PYTHONPATH=.. python3 ./tlstest.py client localhost:4433 .
+else
+	coverage3 run --append --branch --source tlslite -m unittest discover
+endif
+	PYTHONPATH=. COVERAGE_FILE=.coverage.3.server coverage3 run --branch --source tlslite tests/tlstest.py server localhost:4433 tests & sleep 4
+	PYTHONPATH=. COVERAGE_FILE=.coverage.3.client coverage3 run --branch --source tlslite tests/tlstest.py client localhost:4433 tests
 endif
 ifndef PYTHON2
 ifndef PYTHON3
 	@echo "Running test suite with default Python"
+ifndef COVERAGE
 	python -m unittest discover -v
-	cd tests/ && PYTHONPATH=.. python ./tlstest.py server localhost:4433 . & sleep 4
-	cd tests/ && PYTHONPATH=.. python ./tlstest.py client localhost:4433 .
+else
+	coverage run --branch --source tlslite -m unittest discover
+endif
+	PYTHONPATH=. COVERAGE_FILE=.coverage.server coverage run --branch --source tlslite tests/tlstest.py server localhost:4433 tests & sleep 4
+	PYTHONPATH=. COVERAGE_FILE=.coverage.client coverage run --branch --source tlslite tests/tlstest.py client localhost:4433 tests
 endif
 endif
 	$(MAKE) -C docs dummy
 	pylint --msg-template="{path}:{line}: [{msg_id}({symbol}), {obj}] {msg}" tlslite > pylint_report.txt || :
 	diff-quality --violations=pylint --fail-under=90 pylint_report.txt
 ifdef COVERAGE2
-	coverage2 run --branch --source tlslite -m unittest discover
+	coverage2 combine --append
 	coverage2 report -m
 	coverage2 xml
 	diff-cover --fail-under=90 coverage.xml
 endif
 ifdef COVERAGE3
-	coverage3 run --branch --source tlslite -m unittest discover
 	coverage3 report -m
 	coverage3 xml
 	diff-cover --fail-under=90 coverage.xml
@@ -85,7 +96,7 @@ endif
 ifndef COVERAGE2
 ifndef COVERAGE3
 ifdef COVERAGE
-	coverage run --branch --source tlslite -m unittest discover
+	coverage combine --append
 	coverage report -m
 	coverage xml
 	diff-cover --fail-under=90 coverage.xml

--- a/build-requirements.txt
+++ b/build-requirements.txt
@@ -1,3 +1,2 @@
 pylint
 diff_cover
-coveralls

--- a/tests/tlstest.py
+++ b/tests/tlstest.py
@@ -971,8 +971,10 @@ def serverTestCmd(argv):
     connection.close()
 
     if tackpyLoaded:
-        tack = Tack.createFromPem(open("./TACK1.pem", "rU").read())
-        tackUnrelated = Tack.createFromPem(open("./TACKunrelated.pem", "rU").read())    
+        tack = Tack.createFromPem(
+            open(os.path.join(dir, "TACK1.pem"), "rU").read())
+        tackUnrelated = Tack.createFromPem(
+            open(os.path.join(dir, "TACKunrelated.pem"), "rU").read())
 
         settings = HandshakeSettings()
         settings.useExperimentalTackExtension = True


### PR DESCRIPTION
Make coverage reporting (coveralls) run again on Python2.6 and Python3.2

collect coverage also from runs of the old test suite

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/tomato42/tlslite-ng/269)
<!-- Reviewable:end -->
