### PR TITLE
fix PSK identity parsing in tls.py in python3

### DIFF
--- a/scripts/tls.py
+++ b/scripts/tls.py
@@ -173,7 +173,7 @@ def handleArgs(argv, argString, flagsList=[]):
         elif opt == "--psk":
             psk = a2b_hex(arg)
         elif opt == "--psk-ident":
-            psk_ident = arg
+            psk_ident = bytearray(arg, 'utf-8')
         elif opt == "--psk-sha384":
             psk_hash = 'sha384'
         elif opt == "--resumption":


### PR DESCRIPTION
the PSK identity should be a byte string

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/tomato42/tlslite-ng/272)
<!-- Reviewable:end -->
