### PR TITLE
fix FFDHE key exchange in TLS 1.3

### DIFF
--- a/unit_tests/test_tlslite_keyexchange.py
+++ b/unit_tests/test_tlslite_keyexchange.py
@@ -1726,3 +1726,21 @@ class TestFFDHKeyExchange(unittest.TestCase):
         # verify that numbers are zero-padded on MSBs
         self.assertEqual(shared,
                 bytearray(b'\x00' * 255 + b'\x10'))
+
+    def test_calc_shared_secret_for_bytearray_input(self):
+        kex = FFDHKeyExchange(GroupName.ffdhe2048, (3, 4))
+
+        private = 2
+        key_share = bytearray(b'\x00' * 255 + b'\x04')
+        shared = kex.calc_shared_key(private, key_share)
+        # verify that numbers are zero-padded on MSBs
+        self.assertEqual(shared,
+                bytearray(b'\x00' * 255 + b'\x10'))
+
+    def test_calc_shared_secret_for_invalid_sized_input(self):
+        kex = FFDHKeyExchange(GroupName.ffdhe2048, (3, 4))
+
+        private = 2
+        key_share = bytearray(b'\x00' * 10 + b'\x04')
+        with self.assertRaises(TLSIllegalParameterException):
+            kex.calc_shared_key(private, key_share)


### PR DESCRIPTION
in TLS 1.3 the FFDH key share must be the size of the
prime while it could have been padded or had the zero
bytes truncated in TLS 1.2 and earlier

that means it needs to be passed as a bytearray to key
exchange handling methods while the it was passed as an
integer previously

make the funcion handle both inputs and verify the size
of the share in case of TLS 1.3-like call

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/tomato42/tlslite-ng/274)
<!-- Reviewable:end -->
