### PR TITLE
Send alert for malformed finished

### DIFF
--- a/tlslite/tlsconnection.py
+++ b/tlslite/tlsconnection.py
@@ -2084,7 +2084,9 @@ class TLSConnection(TLSRecordLayer):
                                         if i.group == selected_group)
                     break
             else:
-                raise TLSInternalError("HRR did not work?!")
+                for result in self._sendError(AlertDescription.internal_error,
+                                              "HRR did not work?!"):
+                    yield result
 
         psk = None
         selected_psk = None
@@ -2257,7 +2259,10 @@ class TLSConnection(TLSRecordLayer):
                                      padType,
                                      hashName,
                                      saltLen):
-                raise TLSInternalError("Certificate Verify signature failed")
+                for result in self._sendError(
+                        AlertDescription.internal_error,
+                        "Certificate Verify signature failed"):
+                    yield result
             certificate_verify.create(signature, signature_scheme)
 
             for result in self._sendMsg(certificate_verify):

--- a/tlslite/tlsconnection.py
+++ b/tlslite/tlsconnection.py
@@ -2320,7 +2320,10 @@ class TLSConnection(TLSRecordLayer):
         cl_finished = result
         assert isinstance(cl_finished, Finished)
         if cl_finished.verify_data != cl_verify_data:
-            raise TLSDecryptionFailed("Finished value is not valid")
+            for result in self._sendError(
+                    AlertDescription.decrypt_error,
+                    "Finished value is not valid"):
+                yield result
 
         resumption_master_secret = derive_secret(secret,
                                                  bytearray(b'res master'),


### PR DESCRIPTION
When the Finished message is malformed, actually send the alert before closing the connection

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/tomato42/tlslite-ng/276)
<!-- Reviewable:end -->
