### PR TITLE
Simple fixes

### DIFF
--- a/scripts/tls.py
+++ b/scripts/tls.py
@@ -11,6 +11,7 @@ import sys
 import os
 import os.path
 import socket
+import struct
 import time
 import getopt
 import binascii
@@ -484,6 +485,8 @@ def serverCmd(argv):
                 start = time.clock()
                 connection.setsockopt(socket.IPPROTO_TCP, socket.TCP_NODELAY,
                                       1)
+                connection.setsockopt(socket.SOL_SOCKET, socket.SO_LINGER,
+                                      struct.pack('ii', 1, 1))
                 connection.handshakeServer(certChain=cert_chain,
                                               privateKey=privateKey,
                                               verifierDB=verifierDB,

--- a/tlslite/tlsconnection.py
+++ b/tlslite/tlsconnection.py
@@ -2211,9 +2211,9 @@ class TLSConnection(TLSRecordLayer):
             ext = SupportedGroupsExtension()
             groups = [getattr(GroupName, i) for i in settings.keyShares]
             groups += [getattr(GroupName, i) for i in settings.eccCurves
-                       if i not in groups]
+                       if getattr(GroupName, i) not in groups]
             groups += [getattr(GroupName, i) for i in settings.dhGroups
-                       if i not in groups]
+                       if getattr(GroupName, i) not in groups]
             if groups:
                 ext.create(groups)
                 ee_extensions.append(ext)


### PR DESCRIPTION
Few simple fixes:
 - tell kernel to deliver all queued data on connection close
 - don't send duplicate ids in supported_groups in Encrypted Extensions

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/tomato42/tlslite-ng/284)
<!-- Reviewable:end -->
