### PR TITLE
change to draft-28

### DIFF
--- a/tlslite/constants.py
+++ b/tlslite/constants.py
@@ -15,7 +15,7 @@ from .utils.compat import a2b_hex
 
 # protocol version number used for negotiating TLS 1.3 between implementations
 # of the draft specification
-TLS_1_3_DRAFT = (127, 26)
+TLS_1_3_DRAFT = (127, 28)
 
 
 # ServerHello.random value meaning that the message is a HelloRetryRequest


### PR DESCRIPTION
Since OpenSSL supports both 26 and 28, NSS supports only 28 now and GnuTLS
soon with support draft-28
(https://gitlab.com/gnutls/gnutls/merge_requests/696)
it will be easier to test if tlslite-ng and tlsfuzzer do default to
draft 28 too