### PR TITLE
Send handshake messages in as few records as possible, send multiple new session tickets

### DIFF
--- a/tlslite/handshakesettings.py
+++ b/tlslite/handshakesettings.py
@@ -255,6 +255,7 @@ class HandshakeSettings(object):
         self.ticketCipher = "aes256gcm"
         self.ticketLifetime = 24 * 60 * 60
         self.max_early_data = 2 ** 14 + 16  # full record + tag
+        self.ticket_count = 2
         self.record_size_limit = 2**14 + 1  # TLS 1.3 includes content type
 
     def __init__(self):
@@ -475,6 +476,10 @@ class HandshakeSettings(object):
         if not 0 < other.max_early_data <= 2**64:
             raise ValueError("max_early_data must be between 0 and 2GiB")
 
+        if not 0 < other.ticket_count < 2**16:
+            raise ValueError("Incorrect amount for number of new session "
+                             "tickets to send")
+
     def _copy_cipher_settings(self, other):
         """Copy values related to cipher selection."""
         other.cipherNames = self.cipherNames
@@ -498,6 +503,7 @@ class HandshakeSettings(object):
         other.ticketCipher = self.ticketCipher
         other.ticketLifetime = self.ticketLifetime
         other.max_early_data = self.max_early_data
+        other.ticket_count = self.ticket_count
         other.record_size_limit = self.record_size_limit
 
     @staticmethod

--- a/tlslite/handshakesettings.py
+++ b/tlslite/handshakesettings.py
@@ -260,6 +260,8 @@ class HandshakeSettings(object):
         self.ticketCipher = "aes256gcm"
         self.ticketLifetime = 24 * 60 * 60
         self.max_early_data = 2 ** 14 + 16  # full record + tag
+        # send two tickets so that client can quickly ramp up number of
+        # resumed connections (as tickets are single-use in TLS 1.3
         self.ticket_count = 2
         self.record_size_limit = 2**14 + 1  # TLS 1.3 includes content type
 

--- a/tlslite/handshakesettings.py
+++ b/tlslite/handshakesettings.py
@@ -186,12 +186,17 @@ class HandshakeSettings(object):
         tickets. First entry is the encryption key for new tickets and the
         default decryption key, subsequent entries are the fallback keys
         allowing for key rollover. The keys need to be of size appropriate
-        for a selected cipher in ticketCipher, 32 bytes for 'aes256gcm'.
+        for a selected cipher in ticketCipher, 32 bytes for 'aes256gcm' and
+        'chacha20-poly1305', 16 bytes for 'aes128-gcm'.
+        New keys should be generated regularly and replace old ones. Key use
+        time should generally not be longer than 24h and key life-time should
+        not be longer than 48h.
         Leave empty to disable session ticket support on server side.
 
     :vartype ticketCipher: str
     :ivar ticketCipher: name of the cipher used for encrypting the session
-        tickets. 'aes256gcm' by default
+        tickets. 'aes256gcm' by default, 'aes128gcm' or 'chacha20-poly1305'
+        alternatively.
 
     :vartype ticketLifetime: int
     :ivar ticketLifetime: maximum allowed lifetime of ticket encryption key,

--- a/tlslite/tlsrecordlayer.py
+++ b/tlslite/tlsrecordlayer.py
@@ -179,6 +179,9 @@ class TLSRecordLayer(object):
         # we sent
         self.heartbeat_response_callback = None
 
+        self._buffer_content_type = None
+        self._buffer = bytearray()
+
     @property
     def _send_record_limit(self):
         """Maximum size of payload that can be sent."""
@@ -626,7 +629,7 @@ class TLSRecordLayer(object):
         raise TLSLocalAlert(alert, errorStr)
 
     def _sendMsgs(self, msgs):
-        # send messages together
+        # send messages together in a single TCP write
         self.sock.buffer_writes = True
         randomizeFirstBlock = True
         for msg in msgs:
@@ -636,7 +639,7 @@ class TLSRecordLayer(object):
         self.sock.flush()
         self.sock.buffer_writes = False
 
-    def _sendMsg(self, msg, randomizeFirstBlock = True):
+    def _sendMsg(self, msg, randomizeFirstBlock=True, update_hashes=True):
         """Fragment and send message through socket"""
         #Whenever we're connected and asked to send an app data message,
         #we first send the first byte of the message.  This prevents
@@ -654,7 +657,7 @@ class TLSRecordLayer(object):
         buf = msg.write()
         contentType = msg.contentType
         #Update handshake hashes
-        if contentType == ContentType.handshake:
+        if update_hashes and contentType == ContentType.handshake:
             self._handshake_hash.update(buf)
 
         #Fragment big messages
@@ -669,6 +672,27 @@ class TLSRecordLayer(object):
         msgFragment = Message(contentType, buf)
         for result in self._sendMsgThroughSocket(msgFragment):
             yield result
+
+    def _queue_message(self, msg):
+        """Just queue message for sending, for record layer coalescing."""
+        if self._buffer_content_type is not None and \
+                self._buffer_content_type != msg.contentType:
+            raise ValueError("Queuing of wrong message types")
+        if self._buffer_content_type is None:
+            self._buffer_content_type = msg.contentType
+
+        serialised_msg = msg.write()
+        self._buffer += serialised_msg
+        if msg.contentType == ContentType.handshake:
+            self._handshake_hash.update(serialised_msg)
+
+    def _queue_flush(self):
+        """Send the queued messages."""
+        msg = Message(self._buffer_content_type, self._buffer)
+        for result in self._sendMsg(msg, update_hashes=False):
+            yield result
+        self._buffer_content_type = None
+        self._buffer = bytearray()
 
     def _sendMsgThroughSocket(self, msg):
         """Send message, handle errors"""


### PR DESCRIPTION
support for sending multiple messages of the same type in single record,
coalesce the server encrypted flight and session tickets, when
there are multiple to be sent

add support for sending multiple session tickets

rework key derivation for session tickets to prevent IV collisions

fixes #286 

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/tomato42/tlslite-ng/287)
<!-- Reviewable:end -->
