### PR TITLE
make Python_RSAKey multithread safe

### DIFF
--- a/tlslite/utils/python_rsakey.py
+++ b/tlslite/utils/python_rsakey.py
@@ -2,7 +2,7 @@
 # See the LICENSE file for legal information regarding use of this file.
 
 """Pure-Python RSA implementation."""
-
+import threading
 from .cryptomath import *
 from .asn1parser import ASN1Parser
 from .rsakey import *
@@ -33,33 +33,36 @@ class Python_RSAKey(RSAKey):
         self.qInv = qInv
         self.blinder = 0
         self.unblinder = 0
+        self._lock = threading.Lock()
 
     def hasPrivateKey(self):
         return self.d != 0
 
     def _rawPrivateKeyOp(self, m):
-        #Create blinding values, on the first pass:
-        if not self.blinder:
-            self.unblinder = getRandomNumber(2, self.n)
-            self.blinder = powMod(invMod(self.unblinder, self.n), self.e,
-                                  self.n)
+        with self._lock:
+            # Create blinding values, on the first pass:
+            if not self.blinder:
+                self.unblinder = getRandomNumber(2, self.n)
+                self.blinder = powMod(invMod(self.unblinder, self.n), self.e,
+                                      self.n)
+            unblinder = self.unblinder
+            blinder = self.blinder
 
-        #Blind the input
-        m = (m * self.blinder) % self.n
+            # Update blinding values
+            self.blinder = (self.blinder * self.blinder) % self.n
+            self.unblinder = (self.unblinder * self.unblinder) % self.n
 
-        #Perform the RSA operation
+        # Blind the input
+        m = (m * blinder) % self.n
+
+        # Perform the RSA operation
         c = self._rawPrivateKeyOpHelper(m)
 
-        #Unblind the output
-        c = (c * self.unblinder) % self.n
+        # Unblind the output
+        c = (c * unblinder) % self.n
 
-        #Update blinding values
-        self.blinder = (self.blinder * self.blinder) % self.n
-        self.unblinder = (self.unblinder * self.unblinder) % self.n
-
-        #Return the output
+        # Return the output
         return c
-
 
     def _rawPrivateKeyOpHelper(self, m):
         #Non-CRT version


### PR DESCRIPTION
because the same key can be used by server handling multiple
clients, the private key op must be multithread safe

as the blinding value can be generated by multiple threads calling
the method at the same time, or it can be later updated twice while
the unblinder is updated just once (and similar concurency issues)
all those operations need to be handled in a single thread at a time

alternative would be to generate a blinder and unblinder for every call,
hard to say what would scale better

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/tomato42/tlslite-ng/297)
<!-- Reviewable:end -->
