### PR TITLE
send alert msg about invalid key_share

### DIFF
--- a/tlslite/tlsconnection.py
+++ b/tlslite/tlsconnection.py
@@ -2145,8 +2145,14 @@ class TLSConnection(TLSRecordLayer):
             kex = self._getKEX(selected_group, version)
             key_share = self._genKeyShareEntry(selected_group, version)
 
-            shared_sec = kex.calc_shared_key(key_share.private,
-                                             cl_key_share.key_exchange)
+            try:
+                shared_sec = kex.calc_shared_key(key_share.private,
+                                                 cl_key_share.key_exchange)
+            except TLSIllegalParameterException as alert:
+                for result in self._sendError(
+                        AlertDescription.illegal_parameter,
+                        str(alert)):
+                    yield result
 
             sh_extensions.append(ServerKeyShareExtension().create(key_share))
         elif (psk is not None and


### PR DESCRIPTION
When tlslite-ng detected invalid key_share, it just raised `TLSIllegalParameterException` but did not send this alert to client.

This PR should fix this.

fix for testing https://github.com/tomato42/tlsfuzzer/issues/273

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/tomato42/tlslite-ng/304)
<!-- Reviewable:end -->
