### PR TITLE
rsa-pss signatures

### DIFF
--- a/tlslite/tlsconnection.py
+++ b/tlslite/tlsconnection.py
@@ -3649,12 +3649,14 @@ class TLSConnection(TLSRecordLayer):
                         continue
                     # advertise support for both rsaEncryption and RSA-PSS OID
                     # key type
-                    sigAlgs.append(getattr(SignatureScheme,
-                                           "rsa_{0}_rsae_{1}"
-                                           .format(schemeName, hashName)))
-                    sigAlgs.append(getattr(SignatureScheme,
-                                           "rsa_{0}_pss_{1}"
-                                           .format(schemeName, hashName)))
+                    if certType != 'rsa-pss':
+                        sigAlgs.append(getattr(SignatureScheme,
+                                               "rsa_{0}_rsae_{1}"
+                                               .format(schemeName, hashName)))
+                    if certType != 'rsa':
+                        sigAlgs.append(getattr(SignatureScheme,
+                                               "rsa_{0}_pss_{1}"
+                                               .format(schemeName, hashName)))
                 except AttributeError:
                     if schemeName == 'pkcs1':
                         sigAlgs.append((getattr(HashAlgorithm, hashName),

--- a/unit_tests/test_tlslite_constants.py
+++ b/unit_tests/test_tlslite_constants.py
@@ -219,3 +219,13 @@ class TestSignatureScheme(unittest.TestCase):
         ret = SignatureScheme.getHash('rsa_pss_pss_sha384')
 
         self.assertEqual(ret, 'sha384')
+
+    def test_getKeyType_with_valid_new_name(self):
+        ret = SignatureScheme.getKeyType('rsa_pss_pss_sha384')
+
+        self.assertEqual(ret, 'rsa')
+
+    def test_getPadding_with_valid_new_name(self):
+        ret = SignatureScheme.getPadding('rsa_pss_pss_sha256')
+
+        self.assertEqual(ret, 'pss')


### PR DESCRIPTION
TLS1.3 changed in that there are different signature schemes based on whether the signing key (and thus associated certificate) is of a rsa-pss key or of a rsaEncryption key.

That means, when creating signature, we need to select the correct algorithm for the ServerKeyExchange or CertificateVerify.

tests were passing because #279 is not fixed

fixes #275 

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/tomato42/tlslite-ng/311)
<!-- Reviewable:end -->
