### PR TITLE
use pycparser compatible with py2.6

### DIFF
--- a/build-requirements-2.6.txt
+++ b/build-requirements-2.6.txt
@@ -7,3 +7,4 @@ hypothesis<3
 coveralls<1.3.0
 pylint
 diff_cover
+pycparser<2.19


### PR DESCRIPTION
new version dropped support for 2.6

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/tomato42/tlslite-ng/312)
<!-- Reviewable:end -->
