### PR TITLE
allow reading a chain of certificates with -c option

### DIFF
--- a/scripts/tls.py
+++ b/scripts/tls.py
@@ -142,9 +142,8 @@ def handleArgs(argv, argString, flagsList=[]):
             s = open(arg, "rb").read()
             if sys.version_info[0] >= 3:
                 s = str(s, 'utf-8')
-            x509 = X509()
-            x509.parse(s)
-            cert_chain = X509CertChain([x509])
+            cert_chain = X509CertChain()
+            cert_chain.parsePemList(s)
         elif opt == "-u":
             username = arg
         elif opt == "-p":


### PR DESCRIPTION
more complex testing requires support for loading a full chain of
certificates and sending them to the client. Add support for that in
`tls.py`

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/tomato42/tlslite-ng/313)
<!-- Reviewable:end -->
