### PR TITLE
fix Python 2.6 builds

### DIFF
--- a/build-requirements-2.6.txt
+++ b/build-requirements-2.6.txt
@@ -8,3 +8,4 @@ coveralls<1.3.0
 pylint
 diff_cover
 pycparser<2.19
+idna<2.8

--- a/unit_tests/test_tlslite_utils_deprecations.py
+++ b/unit_tests/test_tlslite_utils_deprecations.py
@@ -19,6 +19,30 @@ except ImportError:
 from tlslite.utils.deprecations import deprecated_params, \
         deprecated_attrs, deprecated_class_name
 
+# see https://github.com/pytest-dev/py/issues/110
+# preload the list until the list of loaded modules is static
+try:
+    import py.error
+except ImportError:
+    pass  # ignore
+import sys
+while True:
+    end = True
+    for v in list(sys.modules.values()):
+        old = set(sys.modules.values())
+        _ = getattr(v, '__warningregistry__', None)
+        new = set(sys.modules.values())
+        if new - old:
+            end = False
+    if end:
+        break
+for v in list(sys.modules.values()):
+    old = set(sys.modules.values())
+    _ = getattr(v, '__warningregistry__', None)
+    new = set(sys.modules.values())
+    if new - old:
+        print("changed: {0}".format(new - old))
+
 
 class TestDeprecatedClassName(unittest.TestCase):
     def test_check_class(self):


### PR DESCRIPTION
new idna dropped suppport for 2.6 so use the old one

there are also problems with warnings module on py3.2 and py3.3 so fix them

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/tomato42/tlslite-ng/323)
<!-- Reviewable:end -->
