### PR TITLE
TLS1.3 downgrade sentinel

### DIFF
--- a/tlslite/constants.py
+++ b/tlslite/constants.py
@@ -23,6 +23,14 @@ TLS_1_3_DRAFT = (3, 4)
 TLS_1_3_HRR = a2b_hex("CF21AD74E59A6111BE1D8C021E65B891"
                       "C2A211167ABB8C5E079E09E2C8A8339C")
 
+# last bytes of ServerHello.random to be used when negotiating TLS 1.1 or
+# earlier while supporting TLS 1.2 or greater
+TLS_1_1_DOWNGRADE_SENTINEL = a2b_hex("444F574E47524400")
+
+# last bytes of ServerHello.random to be used when negotiating TLS 1.2
+# while supporting TLS 1.3 or greater
+TLS_1_2_DOWNGRADE_SENTINEL = a2b_hex("444F574E47524401")
+
 
 class TLSEnum(object):
     """Base class for different enums of TLS IDs"""

--- a/tlslite/tlsconnection.py
+++ b/tlslite/tlsconnection.py
@@ -1943,7 +1943,13 @@ class TLSConnection(TLSRecordLayer):
             extensions = None
 
         serverHello = ServerHello()
-        serverHello.create(self.version, getRandomBytes(32), sessionID, \
+        # RFC 8446, section 4.1.3
+        random = getRandomBytes(32)
+        if version == (3, 3) and settings.maxVersion > (3, 3):
+            random[-8:] = TLS_1_2_DOWNGRADE_SENTINEL
+        if version < (3, 3) and settings.maxVersion >= (3, 3):
+            random[-8:] = TLS_1_1_DOWNGRADE_SENTINEL
+        serverHello.create(self.version, random, sessionID,
                            cipherSuite, CertificateType.x509, tackExt,
                            nextProtos, extensions=extensions)
 


### PR DESCRIPTION
implement support for downgrade sentinel and allow for testing its behaviour with older protocol versions in tlsfuzzer

this is part of work towards #306 

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/tomato42/tlslite-ng/324)
<!-- Reviewable:end -->
