### PR TITLE
Replaced time.clock() with timeStamp()

### DIFF
--- a/scripts/tls.py
+++ b/scripts/tls.py
@@ -12,7 +12,6 @@ import os
 import os.path
 import socket
 import struct
-import time
 import getopt
 import binascii
 try:
@@ -34,7 +33,7 @@ from tlslite.api import *
 from tlslite.constants import CipherSuite, HashAlgorithm, SignatureAlgorithm, \
         GroupName, SignatureScheme
 from tlslite import __version__
-from tlslite.utils.compat import b2a_hex, a2b_hex
+from tlslite.utils.compat import b2a_hex, a2b_hex, time_stamp
 from tlslite.utils.dns_utils import is_valid_hostname
 from tlslite.utils.cryptomath import getRandomBytes
 
@@ -315,6 +314,7 @@ def printExporter(connection, expLabel, expLength):
     print("  Exporter length: {0}".format(expLength))
     print("  Keying material: {0}".format(exp))
 
+    
 def clientCmd(argv):
     (address, privateKey, cert_chain, username, password, expLabel,
             expLength, alpn, psk, psk_ident, psk_hash, resumption, ssl3,
@@ -348,14 +348,14 @@ def clientCmd(argv):
         settings.maxVersion = max_ver
 
     try:
-        start = time.clock()
+        start = time_stamp()
         if username and password:
             connection.handshakeClientSRP(username, password, 
                 settings=settings, serverName=address[0])
         else:
             connection.handshakeClientCert(cert_chain, privateKey,
                 settings=settings, serverName=address[0], alpn=alpn)
-        stop = time.clock()        
+        stop = time_stamp()
         print("Handshake success")        
     except TLSLocalAlert as a:
         if a.description == AlertDescription.user_canceled:
@@ -415,10 +415,10 @@ def clientCmd(argv):
     connection = TLSConnection(sock)
 
     try:
-        start = time.clock()
+        start = time_stamp()
         connection.handshakeClientCert(serverName=address[0], alpn=alpn,
             session=session)
-        stop = time.clock()
+        stop = time_stamp()
         print("Handshake success")
     except TLSLocalAlert as a:
         if a.description == AlertDescription.user_canceled:
@@ -508,7 +508,7 @@ def serverCmd(argv):
                     activationFlags = 3
 
             try:
-                start = time.clock()
+                start = time_stamp()
                 connection.setsockopt(socket.IPPROTO_TCP, socket.TCP_NODELAY,
                                       1)
                 connection.setsockopt(socket.SOL_SOCKET, socket.SO_LINGER,
@@ -526,7 +526,7 @@ def serverCmd(argv):
                                               sni=sni)
                                               # As an example (does not work here):
                                               #nextProtos=[b"spdy/3", b"spdy/2", b"http/1.1"])
-                stop = time.clock()
+                stop = time_stamp()
             except TLSRemoteAlert as a:
                 if a.description == AlertDescription.user_canceled:
                     print(str(a))

--- a/tlslite/utils/compat.py
+++ b/tlslite/utils/compat.py
@@ -9,6 +9,7 @@ import platform
 import math
 import binascii
 import traceback
+import time
 import ecdsa
 
 if sys.version_info >= (3,0):
@@ -68,6 +69,12 @@ if sys.version_info >= (3,0):
         """Return exception information formatted as string"""
         return str(e)
 
+    def time_stamp():
+        """Returns system time as a float"""
+        if sys.version_info >= (3, 3):
+            return time.perf_counter()
+        return time.clock()
+
 else:
     # Python 2.6 requires strings instead of bytearrays in a couple places,
     # so we define this function so it does the conversion if needed.
@@ -122,6 +129,10 @@ else:
                                                     sys.exc_traceback))
         return newStr
     #pylint: enable=no-member
+
+    def time_stamp():
+        """Returns system time as a float"""
+        return time.clock()
 
 try:
     # Fedora and Red Hat Enterprise Linux versions have small curves removed


### PR DESCRIPTION
time.clock() was deprecated since Python 3.3, with time.perf_timer() taking its place.  In versions of Python where both exist, they act identically.  

Created a function timeStamp() which determines which of these to use based on the running Python version.  Replaced all instances of time.clock() with timeStamp().

fixes #327 

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/tomato42/tlslite-ng/330)
<!-- Reviewable:end -->
