### PR TITLE
Resumption cipher mismatch

### DIFF
--- a/tests/tlstest.py
+++ b/tests/tlstest.py
@@ -822,7 +822,7 @@ def clientTestCmd(argv):
         connection.handshakeClientCert(serverName=address[0], session=session,
                                        settings=settings)
     except TLSRemoteAlert as e:
-        assert(str(e) == "handshake_failure")
+        assert(str(e) == "illegal_parameter")
     else:
         raise AssertionError("No exception raised")
     connection.close()
@@ -1649,7 +1649,7 @@ def serverTestCmd(argv):
         connection.handshakeServer(certChain=x509Chain, privateKey=x509Key,
                                    sessionCache=sessionCache)
     except TLSLocalAlert as e:
-        assert(str(e) == "handshake_failure")
+        assert(str(e) == "illegal_parameter")
     else:
         raise AssertionError("no exception raised")
     connection.close()


### PR DESCRIPTION
fix incorrect alerts and minor incompatibility with handling resumption

necessary to make tests added in https://github.com/tomato42/tlsfuzzer/pull/487 pass

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/tomato42/tlslite-ng/334)
<!-- Reviewable:end -->
