### PR TITLE
Fix bug when returning errors for _tryDecrypt

### DIFF
--- a/tlslite/tlsconnection.py
+++ b/tlslite/tlsconnection.py
@@ -2186,11 +2186,11 @@ class TLSConnection(TLSRecordLayer):
 
     def _tryDecrypt(self, settings, identity):
         if not settings.ticketKeys:
-            return
+            return None, None
 
         if len(identity.identity) < 13:
             # too small for an encrypted ticket
-            return
+            return None, None
 
         iv, encrypted_ticket = identity.identity[:12], identity.identity[12:]
         for key in settings.ticketKeys:
@@ -2221,6 +2221,9 @@ class TLSConnection(TLSRecordLayer):
                                                        [new_sess_ticket])
 
             return ((identity.identity, psk, prf), ticket)
+
+        # no keys
+        return None, None
 
     def _serverTLS13Handshake(self, settings, clientHello, cipherSuite,
                               privateKey, serverCertChain, version, scheme,


### PR DESCRIPTION
Shows up as a failure to assign to a tuple in tests that intentionally
break session tickets.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/tomato42/tlslite-ng/336)
<!-- Reviewable:end -->
