### PR TITLE
Fix TLS1.3 handshakes to refuse pkcs1 signatures

### DIFF
--- a/tlslite/tlsconnection.py
+++ b/tlslite/tlsconnection.py
@@ -1336,7 +1336,8 @@ class TLSConnection(TLSRecordLayer):
                         yield result
 
                 availSigAlgs = self._sigHashesToList(settings, privateKey,
-                                                     clientCertChain)
+                                                     clientCertChain,
+                                                     version=(3, 4))
                 signature_scheme = getFirstMatching(availSigAlgs,
                                                     valid_sig_algs)
                 scheme = SignatureScheme.toRepr(signature_scheme)
@@ -2583,7 +2584,8 @@ class TLSConnection(TLSRecordLayer):
             signature_scheme = certificate_verify.signatureAlgorithm
 
             valid_sig_algs = self._sigHashesToList(settings,
-                                                   certList=client_cert_chain)
+                                                   certList=client_cert_chain,
+                                                   version=(3, 4))
             if signature_scheme not in valid_sig_algs:
                 for result in self._sendError(
                         AlertDescription.illegal_parameter,


### PR DESCRIPTION
We were not passing the protocol version to _sigHashesToList so
the fucntion was not stripping pkcs1 signature schemes and allowing
them.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/tomato42/tlslite-ng/339)
<!-- Reviewable:end -->
