### PR TITLE
fix comment typo

### DIFF
--- a/tlslite/constants.py
+++ b/tlslite/constants.py
@@ -482,7 +482,7 @@ class CipherSuite:
     :cvar aes128Suites: ciphersuites which use AES symmetric cipher in CBC mode
         with 128 bit key
     :cvar aes256Suites: ciphersuites which use AES symmetric cipher in CBC mode
-        with 128 bit key
+        with 256 bit key
     :cvar rc4Suites: ciphersuites which use RC4 symmetric cipher with 128 bit
         key
     :cvar shaSuites: ciphersuites which use SHA-1 HMAC integrity mechanism


### PR DESCRIPTION
Fix comment typo in constants.py

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/tomato42/tlslite-ng/352)
<!-- Reviewable:end -->
