### PR TITLE
3des fixes

### DIFF
--- a/tlslite/utils/openssl_tripledes.py
+++ b/tlslite/utils/openssl_tripledes.py
@@ -15,24 +15,37 @@ if m2cryptoLoaded:
 
         def __init__(self, key, mode, IV):
             TripleDES.__init__(self, key, mode, IV, "openssl")
+            self._IV, self._key = IV, key
+            self._context = None
+            self._encrypt = None
+
+        def _init_context(self, encrypt=True):
             cipherType = m2.des_ede3_cbc()
-            self.encrypt_context = m2.cipher_ctx_new()
-            self.decrypt_context = m2.cipher_ctx_new()
-            m2.cipher_init(self.encrypt_context, cipherType, key, IV, 1)
-            m2.cipher_init(self.decrypt_context, cipherType, key, IV, 0)
-            m2.cipher_set_padding(self.encrypt_context, 0)
-            m2.cipher_set_padding(self.decrypt_context, 0)
+            self._context = m2.cipher_ctx_new()
+            m2.cipher_init(self._context, cipherType, self._key, self._IV,
+                           int(encrypt))
+            m2.cipher_set_padding(self._context, 0)
+            self._encrypt = encrypt
 
         def encrypt(self, plaintext):
+            if self._context is None:
+                self._init_context(encrypt=True)
+            else:
+                assert self._encrypt, '.encrypt() not allowed after .decrypt()'
             TripleDES.encrypt(self, plaintext)
-            ciphertext = m2.cipher_update(self.encrypt_context, plaintext)
+            ciphertext = m2.cipher_update(self._context, plaintext)
             return bytearray(ciphertext)
 
         def decrypt(self, ciphertext):
+            if self._context is None:
+                self._init_context(encrypt=False)
+            else:
+                assert not self._encrypt, \
+                       '.decrypt() not allowed after .encrypt()'
             TripleDES.decrypt(self, ciphertext)
-            plaintext = m2.cipher_update(self.decrypt_context, ciphertext)
+            plaintext = m2.cipher_update(self._context, ciphertext)
             return bytearray(plaintext)
 
         def __del__(self):
-            m2.cipher_ctx_free(self.encrypt_context)
-            m2.cipher_ctx_free(self.decrypt_context)
+            if self._context is not None:
+                m2.cipher_ctx_free(self._context)

--- a/tlslite/utils/python_tripledes.py
+++ b/tlslite/utils/python_tripledes.py
@@ -417,6 +417,10 @@ class Python_TripleDES(_baseDes):
         self.name = "3des"
         self.implementation = "python"
 
+        self.__key1.iv = self.iv
+        self.__key2.iv = self.iv
+        self.__key3.iv = self.iv
+
     def encrypt(self, data):
         """Encrypt data and return bytes.
 
@@ -437,9 +441,6 @@ class Python_TripleDES(_baseDes):
             raise ValueError("Invalid data length, must be a multiple "
                              "of {0} bytes".format(self.block_size))
 
-        self.__key1.iv = self.iv
-        self.__key2.iv = self.iv
-        self.__key3.iv = self.iv
         i = 0
         result = []
         while i < len(data):
@@ -473,9 +474,6 @@ class Python_TripleDES(_baseDes):
             raise ValueError("Invalid data length, must be a multiple "
                              "of {0} bytes".format(self.block_size))
 
-        self.__key1.iv = self.iv
-        self.__key2.iv = self.iv
-        self.__key3.iv = self.iv
         i = 0
         result = []
         while i < len(data):

--- a/unit_tests/test_tlslite_utils_tripledes_split.py
+++ b/unit_tests/test_tlslite_utils_tripledes_split.py
@@ -27,8 +27,8 @@ class TestTripleDES(unittest.TestCase):
     _given = given(binary(min_size=24, max_size=24),          # key
                    binary(min_size=8, max_size=8),            # iv
                    binary(min_size=13*8, max_size=13*8),      # plaintext
-                   (tuples(integers(1, 12), integers(1, 12))  # split points
-                       .filter(lambda split_pts: split_pts[0] < split_pts[1])
+                   (tuples(integers(0, 13), integers(0, 13))  # split points
+                       .filter(lambda split_pts: split_pts[0] <= split_pts[1])
                        .map(lambda lengths: [i * 8 for i in lengths])))
 
     def split_test(self, key, iv, plaintext, split_points, make_impl=py_3des):

--- a/unit_tests/test_tlslite_utils_tripledes_split.py
+++ b/unit_tests/test_tlslite_utils_tripledes_split.py
@@ -1,0 +1,81 @@
+# Copyright (c) 2019, Alexander Sosedkin
+#
+# See the LICENSE file for legal information regarding use of this file.
+
+# compatibility with Python 2.6, for that we need unittest2 package,
+# which is not available on 3.3 or 3.4
+try:
+    import unittest2 as unittest
+except ImportError:
+    import unittest
+
+import sys
+
+from hypothesis import given, assume, settings
+from hypothesis.strategies import binary, integers, tuples
+
+from tlslite.utils import cryptomath
+
+import tlslite.utils.python_tripledes
+py_3des = tlslite.utils.python_tripledes.new
+
+
+HYP_SETTINGS = {'deadline': None} if sys.version_info > (2, 7) else {}
+
+
+class TestTripleDES(unittest.TestCase):
+    _given = given(binary(min_size=24, max_size=24),          # key
+                   binary(min_size=8, max_size=8),            # iv
+                   binary(min_size=13*8, max_size=13*8),      # plaintext
+                   (tuples(integers(1, 12), integers(1, 12))  # split points
+                       .filter(lambda split_pts: split_pts[0] < split_pts[1])
+                       .map(lambda lengths: [i * 8 for i in lengths])))
+
+    def split_test(self, key, iv, plaintext, split_points, make_impl=py_3des):
+        i, j = split_points
+
+        ciphertext = make_impl(key, iv).encrypt(plaintext)
+        self.assertEqual(make_impl(key, iv).decrypt(ciphertext), plaintext)
+
+        impl = make_impl(key, iv)
+        pl1, pl2, pl3 = plaintext[:i], plaintext[i:j], plaintext[j:]
+        ci1, ci2, ci3 = impl.encrypt(pl1), impl.encrypt(pl2), impl.encrypt(pl3)
+        self.assertEqual(ci1 + ci2 + ci3, ciphertext)
+
+        impl = make_impl(key, iv)
+        pl1, pl2, pl3 = impl.decrypt(ci1), impl.decrypt(ci2), impl.decrypt(ci3)
+        self.assertEqual(pl1 + pl2 + pl3, plaintext)
+
+        return ciphertext
+
+    @_given
+    @settings(**HYP_SETTINGS)
+    def test_python(self, key, iv, plaintext, split_points):
+        self.split_test(key, iv, plaintext, split_points)
+
+    @unittest.skipIf(not cryptomath.m2cryptoLoaded, "requires M2Crypto")
+    @_given
+    @settings(**HYP_SETTINGS)
+    def test_python_vs_mcrypto(self, key, iv, plaintext, split_points):
+        import tlslite.utils.openssl_tripledes
+        m2_3des = lambda k, iv: tlslite.utils.openssl_tripledes.new(k, 2, iv)
+
+        py_res = self.split_test(key, iv, plaintext, split_points, py_3des)
+        m2_res = self.split_test(key, iv, plaintext, split_points, m2_3des)
+        self.assertEqual(py_res, m2_res)
+
+    @unittest.skipIf(not cryptomath.pycryptoLoaded, "requires pycrypto")
+    @_given
+    @settings(**HYP_SETTINGS)
+    def test_python_vs_pycrypto(self, key, iv, plaintext, split_points):
+        import tlslite.utils.pycrypto_tripledes
+        pc_3des = lambda k, iv: tlslite.utils.pycrypto_tripledes.new(k, 2, iv)
+
+        try:
+            py_res = self.split_test(key, iv, plaintext, split_points, py_3des)
+            pc_res = self.split_test(key, iv, plaintext, split_points, pc_3des)
+            self.assertEqual(py_res, pc_res)
+        except ValueError as e:
+            # pycrypto deliberately rejects weak 3DES keys, skip such keys
+            assume(e.args != ('Triple DES key degenerates to single DES',))
+            raise


### PR DESCRIPTION
Two 3DES fixes - one for the Python implementation, one for the M2Crypto one - and a new test.

```
commit 5c4078185500f835a12423c6bd5b863681c44b08
    Fix IV handling for 3DES, test consecutive calls

    Correctly set IV for consecutive 3DES encrypt/decrypt invocations.
    Test that the results of three invocations yield the same result
    as a combined single one, cross-check this across three implementations.
```

```
commit 8f1fa9bec91ca8c83c77142a3ffb6a5c78e73586
    Streamline M2Crypto 3DES IV handling

    M2Crypto defaults to padding the ciphertext,
    and the previous implementation danced around that awkwardly
    by padding and unpadding ciphertext on decryption
    and updating the IV manually.
    `m2.cipher_set_padding(context, 0)`
    allows to shoulder the IV handling back to where it belongs
    and to get rid of unnecessary context reinitializations.
    (Investigative work courtesy of @tomato42:
     https://github.com/tomato42/tlslite-ng/pull/377#pullrequestreview-323893850)
```

```
commit 69c4aac9c7e35becef17ca0de9aaed694d12dcb1
    Disable test timings analysis in 3DES split tests

    The implementation is slow and (re)execution time varies greatly,
    making hypothesis error out in CI.
    This change disables the timings analysis
    for tests in `test_tlslite_utils_tripledes_split.py`.
```

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/tomato42/tlslite-ng/377)
<!-- Reviewable:end -->
