### PR TITLE
do not send two PHAs

### DIFF
--- a/scripts/tls.py
+++ b/scripts/tls.py
@@ -572,7 +572,7 @@ def serverCmd(argv):
                     else:
                         raise ValueError("Invalid return from "
                                          "send_keyupdate_request")
-            if self.path.startswith('/secret'):
+            if self.path.startswith('/secret') and not request_pha:
                 try:
                     for i in self.connection.request_post_handshake_auth():
                         pass


### PR DESCRIPTION
since with request_pha we send the CertificateRequest always,
if we combine it with `/secret` we end up with two requests

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/tomato42/tlslite-ng/379)
<!-- Reviewable:end -->
