### PR TITLE
TLS 1.3 ECDH and key_shares fixes

### DIFF
--- a/tlslite/keyexchange.py
+++ b/tlslite/keyexchange.py
@@ -23,6 +23,7 @@ from .utils import tlshashlib as hashlib
 from .utils.x25519 import x25519, x448, X25519_G, X448_G, X25519_ORDER_SIZE, \
         X448_ORDER_SIZE
 from .utils.compat import int_types
+from .utils.codec import DecodeError
 
 
 class KeyExchange(object):
@@ -907,7 +908,7 @@ class ECDHKeyExchange(RawDHKeyExchange):
             try:
                 ecdhYc = decodeX962Point(peer_share,
                                          curve)
-            except AssertionError:
+            except (AssertionError, DecodeError):
                 raise TLSIllegalParameterException("Invalid ECC point")
 
             S = ecdhYc * private

--- a/tlslite/tlsconnection.py
+++ b/tlslite/tlsconnection.py
@@ -3127,6 +3127,23 @@ class TLSConnection(TLSRecordLayer):
                             .format(GroupName.toStr(mismatch))):
                         yield result
 
+                key_share_ids = [i.group for i in key_share.client_shares]
+                if len(set(key_share_ids)) != len(key_share_ids):
+                    for result in self._sendError(
+                            AlertDescription.illegal_parameter,
+                            "Client sent multiple key shares for the same "
+                            "group"):
+                        yield result
+
+                group_ids = sup_groups.groups
+                diff = set(group_ids) - set(key_share_ids)
+                if key_share_ids != [i for i in group_ids if i not in diff]:
+                    for result in self._sendError(
+                            AlertDescription.illegal_parameter,
+                            "Client sent key shares in different order than "
+                            "the advertised groups."):
+                        yield result
+
                 sig_algs = clientHello.getExtension(
                     ExtensionType.signature_algorithms)
                 if (not psk_modes or not psk) and sig_algs:

--- a/tlslite/utils/ecc.py
+++ b/tlslite/utils/ecc.py
@@ -3,20 +3,25 @@
 # See the LICENSE file for legal information regarding use of this file.
 """Methods for dealing with ECC points"""
 
-from .codec import Parser, Writer
+from .codec import Parser, Writer, DecodeError
 from .cryptomath import bytesToNumber, numberToByteArray, numBytes
 from .compat import ecdsaAllCurves
 import ecdsa
+
 
 def decodeX962Point(data, curve=ecdsa.NIST256p):
     """Decode a point from a X9.62 encoding"""
     parser = Parser(data)
     encFormat = parser.get(1)
-    assert encFormat == 4
+    if encFormat != 4:
+        raise DecodeError("Not an uncompressed point encoding")
     bytelength = getPointByteSize(curve)
     xCoord = bytesToNumber(parser.getFixBytes(bytelength))
     yCoord = bytesToNumber(parser.getFixBytes(bytelength))
+    if parser.getRemainingLength():
+        raise DecodeError("Invalid length of point encoding for curve")
     return ecdsa.ellipticcurve.Point(curve.curve, xCoord, yCoord)
+
 
 def encodeX962Point(point):
     """Encode a point in X9.62 format"""


### PR DESCRIPTION
fix handling malformed ECDH key shares and malformed key_shares extension

don't create malformed ones ourselves

fixes bugs identified by https://github.com/tomato42/tlsfuzzer/pull/553

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/tomato42/tlslite-ng/388)
<!-- Reviewable:end -->
