### PR TITLE
check if the ciphers are supported by m2crypto before using them

### DIFF
--- a/tlslite/utils/cryptomath.py
+++ b/tlslite/utils/cryptomath.py
@@ -27,9 +27,13 @@ from . import tlshmac as hmac
 # **************************************************************************
 
 # Try to load M2Crypto/OpenSSL
+# pylint: disable=invalid-name
 try:
     from M2Crypto import m2
     m2cryptoLoaded = True
+    M2CRYPTO_AES_CTR = False
+    if hasattr(m2, 'aes_192_ctr'):
+        M2CRYPTO_AES_CTR = True
 
     try:
         with open('/proc/sys/crypto/fips_enabled', 'r') as fipsFile:
@@ -39,8 +43,13 @@ try:
         # looks like we're running in container, likely not FIPS mode
         m2cryptoLoaded = True
 
+    # If AES-CBC is not available, don't use m2crypto
+    if not hasattr(m2, 'aes_192_cbc'):
+        m2cryptoLoaded = False
+
 except ImportError:
     m2cryptoLoaded = False
+# pylint: enable=invalid-name
 
 #Try to load GMPY
 try:

--- a/tlslite/utils/openssl_aes.py
+++ b/tlslite/utils/openssl_aes.py
@@ -5,16 +5,24 @@
 
 from .cryptomath import *
 from .aes import *
+from .python_aes import Python_AES_CTR
 
 if m2cryptoLoaded:
 
     def new(key, mode, IV):
         # IV argument name is a part of the interface
         # pylint: disable=invalid-name
+        """
+        Try using AES CTR from m2crpyto,
+        if it is not available fall back to the
+        python implementation.
+        """
         if mode == 2:
             return OpenSSL_AES(key, mode, IV)
         elif mode == 6:
-            return OpenSSL_CTR(key, mode, IV)
+            if M2CRYPTO_AES_CTR:
+                return OpenSSL_CTR(key, mode, IV)
+            return Python_AES_CTR(key, mode, IV)
         else:
             raise NotImplementedError()
 


### PR DESCRIPTION
fixes #405 

It looks like AES-CTR was introduced in m2crypto version 0.25.0
This adds a method to check if the ciphers are supported and if not, it falls back to the python implementation for that cipher.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/tomato42/tlslite-ng/411)
<!-- Reviewable:end -->
