### PR TITLE
Add support for RSA PKCS1 MD5 in x509 certificates

### DIFF
--- a/tlslite/constants.py
+++ b/tlslite/constants.py
@@ -327,6 +327,8 @@ class AlgorithmOID(TLSEnum):
             SignatureScheme.ecdsa_secp384r1_sha384
     oid[bytes(a2b_hex('06082a8648ce3d040304'))] = \
             SignatureScheme.ecdsa_secp521r1_sha512
+    oid[bytes(a2b_hex('06092a864886f70d010104'))] = \
+            (HashAlgorithm.md5, SignatureAlgorithm.rsa)
     oid[bytes(a2b_hex('06092a864886f70d010105'))] = \
             SignatureScheme.rsa_pkcs1_sha1
     oid[bytes(a2b_hex('06092a864886f70d01010e'))] = \


### PR DESCRIPTION
Add  constants for `rsa_pkcs1_md5` x509 certificates

The `test_toRepr_with_obsolete_value` test fails because of the added value, I'm not too sure if it's by design or not.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/tomato42/tlslite-ng/429)
<!-- Reviewable:end -->
